### PR TITLE
Add VIS video links from program data (2024+2025)

### DIFF
--- a/public/data/paperLinks/10.1109/TVCG.2024.3456141
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456141
@@ -1,3 +1,4 @@
 name,url,icon
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1218.html,other
-Fast Forward Video,https://youtu.be/CrX4jHVmDfU,video
+Fast Forward Video,https://youtu.be/CrX4jHVmDfU,videoPresentation,https://youtu.be/FLsXwoR_H8E,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1218/v-full-1218_Preview.mp4?token=V_BqaYvYHAVkbDe2N4Q-tw9rdfS_5RQGXLTQGgkspUk&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456142
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456142
@@ -2,4 +2,5 @@ name,url,icon
 Paper Preprint,https://arxiv.org/abs/2408.04539,paper
 Supplemental Material,https://github.com/VIS-SUSTech/ParetoTracker,other
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1179.html,other
-Fast Forward Video,https://youtu.be/iExTSj-IaHc,video
+Fast Forward Video,https://youtu.be/iExTSj-IaHc,videoPresentation,https://youtu.be/ESst2nxcXuA,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1179/v-full-1179_Preview.mp4?token=HiWFcD9cnvwRDeNVeu8K30udpLarCgMmf95DedtPB38&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456143
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456143
@@ -2,4 +2,5 @@ name,url,icon
 Paper Preprint,http://arxiv.org/pdf/2409.10649v2,paper
 Supplemental Material,https://github.com/danilka4/ttec,other
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1032.html,other
-Fast Forward Video,https://youtu.be/49ktTLyplJc,video
+Fast Forward Video,https://youtu.be/49ktTLyplJc,videoPresentation,https://youtu.be/H85FqQyR25U,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1032/v-full-1032_Preview.mp4?token=1legcsYWlMjPEyQIyMzGdETw2sOSGdikDiSu2YZj514&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456144
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456144
@@ -2,4 +2,5 @@ name,url,icon
 Paper Preprint,http://arxiv.org/abs/2407.17431,paper
 Supplemental Material,https://github.com/ProvenanceWidgets/Supplemental-Material,other
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1204.html,other
-Fast Forward Video,https://youtu.be/Ed1cZDTTFd0,video
+Fast Forward Video,https://youtu.be/Ed1cZDTTFd0,videoPresentation,https://youtu.be/HC69aABUJuc,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1204/v-full-1204_Preview.mp4?token=NcgZCl_jM23zSL86QflPmp1ABUfon9PW1Ai_9rwx-P0&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456145
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456145
@@ -1,4 +1,5 @@
 name,url,icon
 Paper Preprint,https://arxiv.org/abs/2407.20570,paper
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1096.html,other
-Fast Forward Video,https://youtu.be/KR_r6ARzzx0,video
+Fast Forward Video,https://youtu.be/KR_r6ARzzx0,videoPresentation,https://youtu.be/hEywiCiEJO0,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1096/v-full-1096_Preview.mp4?token=SgWKRslsK3PCv0V7DHhhG02KJ8saIlA87RUWJ-i9jKg&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456150
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456150
@@ -1,3 +1,4 @@
 name,url,icon
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1067.html,other
-Fast Forward Video,https://youtu.be/NWnvzefxILM,video
+Fast Forward Video,https://youtu.be/NWnvzefxILM,videoPresentation,https://youtu.be/hEywiCiEJO0,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1067/v-full-1067_Preview.mp4?token=WdJwebGqoxqRl2J3o3aTwy7jdlbRADEynOHmmZ55jE4&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456155
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456155
@@ -1,4 +1,5 @@
 name,url,icon
 Supplemental Material,https://doi.org/10.17605/OSF.IO/F39J6,other
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1147.html,other
-Fast Forward Video,https://youtu.be/Nr30W716yjI,video
+Fast Forward Video,https://youtu.be/Nr30W716yjI,videoPresentation,https://youtu.be/W3Vrrxo2w74,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1147/v-full-1147_Preview.mp4?token=RSeiBOIa3FraoklgtgzwYzc1xP-0gRTZoGxLbeHvDUg&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456159
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456159
@@ -2,4 +2,5 @@ name,url,icon
 Paper Preprint,https://arxiv.org/abs/2407.20174,paper
 Supplemental Material,https://github.com/zengxingchen/ChartQA-MLLM,other
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1193.html,other
-Fast Forward Video,https://youtu.be/fiE38Zyk9VY,video
+Fast Forward Video,https://youtu.be/fiE38Zyk9VY,videoPresentation,https://youtu.be/hEywiCiEJO0,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1193/v-full-1193_Preview.mp4?token=g7956VuPuX9qXmOO9QhCifFhYpHqQxRR8sdHM3xSlXQ&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456160
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456160
@@ -2,4 +2,5 @@ name,url,icon
 Paper Preprint,https://doi.org/10.48550/arXiv.2407.13107,paper
 Supplemental Material,https://osf.io/qhu7f/,other
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1059.html,other
-Fast Forward Video,https://youtu.be/4AmQkVSrVdE,video
+Fast Forward Video,https://youtu.be/4AmQkVSrVdE,videoPresentation,https://youtu.be/0TNqponA2lk,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1059/v-full-1059_Preview.mp4?token=36Loh-7OLpLaxVBBBoJ5FVLn6dJxoh991w5oHDdNbKQ&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456167
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456167
@@ -2,4 +2,5 @@ name,url,icon
 Paper Preprint,https://hal.science/hal-04668352,paper
 Supplemental Material,https://osf.io/kc3dg/,other
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1214.html,other
-Fast Forward Video,https://youtu.be/8QT8_S2C0fs,video
+Fast Forward Video,https://youtu.be/8QT8_S2C0fs,videoPresentation,https://youtu.be/cJNBh2zSTiU,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1214/v-full-1214_Preview.mp4?token=Eq1d9_8bf1Cs8leruLVlhzqxc5uiAWsof3tZ5n9GSsE&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456168
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456168
@@ -2,4 +2,5 @@ name,url,icon
 Paper Preprint,https://arxiv.org/abs/2407.14433,paper
 Supplemental Material,https://doi.org/10.5281/zenodo.12784670,other
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1153.html,other
-Fast Forward Video,https://youtu.be/vZk9Sm6PIIo,video
+Fast Forward Video,https://youtu.be/vZk9Sm6PIIo,videoPresentation,https://youtu.be/vNaxXisbG4Y,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1153/v-full-1153_Preview.mp4?token=Z6BFddSYmiI-39mV2cow1IHd-5BfUyXrkwS1rpLjwqs&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456171
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456171
@@ -2,4 +2,5 @@ name,url,icon
 Paper Preprint,https://osf.io/preprints/osf/rw35g,paper
 Supplemental Material,https://osf.io/ubrdy/,other
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1077.html,other
-Fast Forward Video,https://youtu.be/x-XyV4J73t4,video
+Fast Forward Video,https://youtu.be/x-XyV4J73t4,videoPresentation,https://youtu.be/d-eG7NRcrKg,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1077/v-full-1077_Preview.mp4?token=6NSXfqcdZIqgeto12eTKiolmd1ailFSS5Ylrv9WGhQA&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456181
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456181
@@ -1,3 +1,4 @@
 name,url,icon
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1039.html,other
-Fast Forward Video,https://youtu.be/orsYGZt1cWI,video
+Fast Forward Video,https://youtu.be/orsYGZt1cWI,videoPresentation,https://youtu.be/7Y2cPfXGiAY,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1039/v-full-1039_Preview.mp4?token=RMStTCRgaLgf8wuswgS8B2S_P9JX_UtU18dAZAvK_6I&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456182
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456182
@@ -2,4 +2,5 @@ name,url,icon
 Paper Preprint,https://arxiv.org/abs/2407.16871,paper
 Supplemental Material,https://osf.io/qmfv6,other
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1256.html,other
-Fast Forward Video,https://youtu.be/bj8YXso5ly0,video
+Fast Forward Video,https://youtu.be/bj8YXso5ly0,videoPresentation,https://youtu.be/rSvwf4L8jPc,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1256/v-full-1256_Preview.mp4?token=ilWiqf4xF0Ne1wq9zXyw97jLPCm2BTpcsVHohWb1yEI&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456186
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456186
@@ -6,4 +6,5 @@ Fast Forward Video,https://youtu.be/2l7HgOd2NIY,video
 Project Website,https://jku-vds-lab.at/publications/2024_loops/,project_website
 Overview Video,https://youtu.be/jCUwLm5wfNo,video
 Source Code,https://github.com/jku-vds-lab/loops,code
-Live Demo,https://mybinder.org/v2/gh/jku-vds-lab/loops/main?labpath=notebooks/Use%20Case%201.ipynb,project_website
+Live Demo,https://mybinder.org/v2/gh/jku-vds-lab/loops/main?labpath=notebooks/Use%20Case%201.ipynb,project_websitePresentation,https://youtu.be/HC69aABUJuc,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1251/v-full-1251_Preview.mp4?token=hfiHy_SBFkr3Cp8zrhAzomuDkTB9gV-gF67EgA19M08&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456187
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456187
@@ -2,4 +2,5 @@ name,url,icon
 Paper Preprint,https://doi.org/10.31219/osf.io/4yc8s,paper
 Supplemental Material,https://osf.io/wnz32/,other
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1026.html,other
-Fast Forward Video,https://youtu.be/H9JJoBZBGNk,video
+Fast Forward Video,https://youtu.be/H9JJoBZBGNk,videoPresentation,https://youtu.be/M8JHVCnERRk,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1026/v-full-1026_Preview.mp4?token=MfxoMMoKp4WxUS5LilcXPAr5s9n5tgd6GhmKH7e3Zp4&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456193
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456193
@@ -7,4 +7,5 @@ Supplemental Material,https://osf.io/3f6kr/,other
 Blog Post,https://vdl.sci.utah.edu/blog/2024/09/30/aardvark/,other
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1232.html,other
 
-Fast Forward Video,https://youtu.be/5kVue1ySnOk,video
+Fast Forward Video,https://youtu.be/5kVue1ySnOk,videoPresentation,https://youtu.be/d-eG7NRcrKg,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1232/v-full-1232_Preview.mp4?token=LCnEMjUCrDIXrJNKZSfQPb2d5F8T_eckC8Qqrdxmxa0&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456199
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456199
@@ -2,4 +2,5 @@ name,url,icon
 Paper Preprint,https://arxiv.org/abs/2408.02508,paper
 Supplemental Material,https://osf.io/94ebr/,other
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1128.html,other
-Fast Forward Video,https://youtu.be/obWhz2SJuzg,video
+Fast Forward Video,https://youtu.be/obWhz2SJuzg,videoPresentation,https://youtu.be/H85FqQyR25U,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1128/v-full-1128_Preview.mp4?token=xhnURLvMH8Q9yodeDEVJde2vWGBMegY00mSFQlcFmj4&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456200
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456200
@@ -1,3 +1,4 @@
 name,url,icon
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1099.html,other
-Fast Forward Video,https://youtu.be/LQ89KZHc_uY,video
+Fast Forward Video,https://youtu.be/LQ89KZHc_uY,videoPresentation,https://youtu.be/SOrXiceBb2g,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1099/v-full-1099_Preview.mp4?token=EIieXd4BF-80sryrgj0510wUCzzsyFdEgrbI1J5DqPY&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456215
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456215
@@ -2,4 +2,5 @@ name,url,icon
 Paper Preprint,https://arxiv.org/abs/2407.16329,paper
 Supplemental Material,https://osf.io/q6yc4/,other
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1121.html,other
-Fast Forward Video,https://youtu.be/K9vSYLsemPM,video
+Fast Forward Video,https://youtu.be/K9vSYLsemPM,videoPresentation,https://youtu.be/TkBPnodArzQ,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1121/v-full-1121_Preview.mp4?token=lSkRirWnWHhBzgGO2eXgj7s4VeGJqJXdwF--jEY_GC8&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456216
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456216
@@ -1,3 +1,4 @@
 name,url,icon
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1031.html,other
-Fast Forward Video,https://youtu.be/p07D01bK_fs,video
+Fast Forward Video,https://youtu.be/p07D01bK_fs,videoPresentation,https://youtu.be/SOrXiceBb2g,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1031/v-full-1031_Preview.mp4?token=lZJeB6Xf0ge_YdGbBTun3RHwlGjYyPFmJbqOYHb7olQ&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456291
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456291
@@ -2,4 +2,5 @@ name,url,icon
 Paper Preprint,https://osf.io/preprints/osf/kg3am,paper
 Supplemental Material,https://osf.io/w5pum/,other
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1738.html,other
-Fast Forward Video,https://youtu.be/j5kScTwQeNk,video
+Fast Forward Video,https://youtu.be/j5kScTwQeNk,videoPresentation,https://youtu.be/W3Vrrxo2w74,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1738/v-full-1738_Preview.mp4?token=HOTx4l7qDky3PAIN5UrGhIlD6SAGmJngXtES3wC48p8&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456296
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456296
@@ -2,4 +2,5 @@ name,url,icon
 Paper Preprint,http://arxiv.org/pdf/2408.04798v1,paper
 Supplemental Material,https://mascot-vis.github.io/,other
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1416.html,other
-Fast Forward Video,https://youtu.be/4IYhlRFnM64,video
+Fast Forward Video,https://youtu.be/4IYhlRFnM64,videoPresentation,https://youtu.be/NWNMgWnT7NM,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1416/v-full-1416_Preview.mp4?token=KRrGLYZSqDhpGaEVGwui2BSZujcpuzBKO2MyQZHZ4OU&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456298
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456298
@@ -2,4 +2,5 @@ name,url,icon
 Paper Preprint,https://osf.io/preprints/osf/6f42j,paper
 Supplemental Material,https://osf.io/bdj4v/,other
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1342.html,other
-Fast Forward Video,https://youtu.be/Tw14XEoGMAk,video
+Fast Forward Video,https://youtu.be/Tw14XEoGMAk,videoPresentation,https://youtu.be/55Jz0Cdvl1k,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1342/v-full-1342_Preview.mp4?token=rhgoNF1TgG9XLA_Pd4l2NUgw86TcNAfNZPBjnPYalgE&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456300
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456300
@@ -2,4 +2,5 @@ name,url,icon
 Paper Preprint,https://arxiv.org/abs/2404.10732,paper
 Supplemental Material,https://osf.io/8mfhp/,other
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1480.html,other
-Fast Forward Video,https://youtu.be/cDGkQpk85yw,video
+Fast Forward Video,https://youtu.be/cDGkQpk85yw,videoPresentation,https://youtu.be/gaAm2v-ENKA,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1480/v-full-1480_Preview.mp4?token=6hU4GabNxurQqMyFUGJ3MOpoqLwws2FyOL0qkKNd3Uk&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456304
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456304
@@ -2,4 +2,5 @@ name,url,icon
 Paper Preprint,http://arxiv.org/abs/2407.19364,paper
 Supplemental Material,https://github.com/Vanellope7/Defogger,other
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1438.html,other
-Fast Forward Video,https://youtu.be/BDNvBU24Hls,video
+Fast Forward Video,https://youtu.be/BDNvBU24Hls,videoPresentation,https://youtu.be/3FAi9iPZPRA,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1438/v-full-1438_Preview.mp4?token=uETUHjyLsHeNXUZg0czlJ92MqaE_uZaICE3o3vENo_A&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456305
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456305
@@ -2,4 +2,5 @@ name,url,icon
 Paper Preprint,https://arxiv.org/abs/2407.11625,paper
 Supplemental Material,https://visva.cs.uni-koeln.de/en/publications/beware-of-validation-by-eye-visual-validation-of-linear-trends-in-scatterplots,other
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1547.html,other
-Fast Forward Video,https://youtu.be/-Ohr2rTpvXI,video
+Fast Forward Video,https://youtu.be/-Ohr2rTpvXI,videoPresentation,https://youtu.be/ESst2nxcXuA,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1547/v-full-1547_Preview.mp4?token=SSXo5mnJOmbYrf5k4_9Y7_5zEcT5DmSz-KJd7OTPcyo&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456306
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456306
@@ -2,4 +2,5 @@ name,url,icon
 Paper Preprint,https://arxiv.org/abs/2407.18705,paper
 Supplemental Material,https://gitlab.fi.muni.cz/formela/strategy-vizualizer,other
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1571.html,other
-Fast Forward Video,https://youtu.be/BgFsC5T5ILM,video
+Fast Forward Video,https://youtu.be/BgFsC5T5ILM,videoPresentation,https://youtu.be/SOrXiceBb2g,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1571/v-full-1571_Preview.mp4?token=f8B5YPqvr32ERZQcdM_iNJ8vQlq0Lo2mxVfog7Id2s8&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456308
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456308
@@ -2,4 +2,5 @@ name,url,icon
 Paper Preprint,https://arxiv.org/abs/2407.17876,paper
 Supplemental Material,https://zenodo.org/records/12772899,other
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1770.html,other
-Fast Forward Video,https://youtu.be/T3hvGmZlBgw,video
+Fast Forward Video,https://youtu.be/T3hvGmZlBgw,videoPresentation,https://youtu.be/H85FqQyR25U,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1770/v-full-1770_Preview.mp4?token=tW2cl0IdREAQh7MB2CO5gIe0FL6l_fBX0wOR_x1bJHI&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456309
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456309
@@ -1,4 +1,5 @@
 name,url,icon
 Paper Preprint,https://osf.io/ysrhq/,paper
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1422.html,other
-Fast Forward Video,https://youtu.be/dA4Z80m5Rzs,video
+Fast Forward Video,https://youtu.be/dA4Z80m5Rzs,videoPresentation,https://youtu.be/W3Vrrxo2w74,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1422/v-full-1422_Preview.mp4?token=yDyFYRJ4pisyltZsmx0eDNmY6u8zITqwq3wrjK1BCnU&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456311
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456311
@@ -2,4 +2,5 @@ name,url,icon
 Paper Preprint,http://arxiv.org/pdf/2408.07483v1,paper
 Supplemental Material,https://vis-atlas.github.io,other
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1446.html,other
-Fast Forward Video,https://youtu.be/S5Pi7FB5Eek,video
+Fast Forward Video,https://youtu.be/S5Pi7FB5Eek,videoPresentation,https://youtu.be/3FAi9iPZPRA,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1446/v-full-1446_Preview.mp4?token=gK7iNaMwM5fAFvMQve39FBaxshqihdeh3jM1dP0VQ34&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456312
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456312
@@ -1,3 +1,4 @@
 name,url,icon
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1809.html,other
-Fast Forward Video,https://youtu.be/z5Loo1vtnXg,video
+Fast Forward Video,https://youtu.be/z5Loo1vtnXg,videoPresentation,https://youtu.be/cJNBh2zSTiU,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1809/v-full-1809_Preview.mp4?token=sYnN8_S710yTFOr4sy8fpyeSUYtQ5sxjnLXbRBwWYls&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456314
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456314
@@ -2,4 +2,5 @@ name,url,icon
 Paper Preprint,https://osf.io/zgphx,paper
 Supplemental Material,https://osf.io/c7yga/,other
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1272.html,other
-Fast Forward Video,https://youtu.be/JAizrYjsDB8,video
+Fast Forward Video,https://youtu.be/JAizrYjsDB8,videoPresentation,https://youtu.be/oBQXVSnxy5g,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1272/v-full-1272_Preview.mp4?token=v8VZzcOwmzW0CadxHJpyhrgdUUg2hMCG4nfe7dEqYWw&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456315
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456315
@@ -1,4 +1,5 @@
 name,url,icon
 Paper Preprint,https://arxiv.org/abs/2407.19464,paper
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1307.html,other
-Fast Forward Video,https://youtu.be/AwIuPtpFz-k,video
+Fast Forward Video,https://youtu.be/AwIuPtpFz-k,videoPresentation,https://youtu.be/vNaxXisbG4Y,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1307/v-full-1307_Preview.mp4?token=lopxc4Sly_btDsX1Mo-dcgzS-HTbPGfRVSfPfSX0QbI&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456316
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456316
@@ -1,4 +1,5 @@
 name,url,icon
 Paper Preprint,https://doi.org/10.48550/arXiv.2408.04031,paper
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1500.html,other
-Fast Forward Video,https://youtu.be/jJowp-dAYp8,video
+Fast Forward Video,https://youtu.be/jJowp-dAYp8,videoPresentation,https://youtu.be/sO33xoUQ9fk,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1500/v-full-1500_Preview.mp4?token=jgv8mXTzZajUyl2IUm_dK6-zrdp-umkLuenVdRWoJN0&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456317
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456317
@@ -2,4 +2,5 @@ name,url,icon
 Paper Preprint,https://arxiv.org/abs/2407.21285,paper
 Supplemental Material,https://osf.io/geauf,other
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1290.html,other
-Fast Forward Video,https://youtu.be/CY7ycxWmLkw,video
+Fast Forward Video,https://youtu.be/CY7ycxWmLkw,videoPresentation,https://youtu.be/yBF6qqK_ASs,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1290/v-full-1290_Preview.mp4?token=NkJBbD0Gt1xNNy93YGu-u2bvj6CkT8d0wcJdXjEMsHY&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456318
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456318
@@ -6,4 +6,5 @@ Preregistration,https://osf.io/4dcav,other
 Preregistration,https://osf.io/d9nmu,other
 Preregistration,https://osf.io/yex32,other
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1275.html,other
-Fast Forward Video,https://youtu.be/SmrTAspA0PM,video
+Fast Forward Video,https://youtu.be/SmrTAspA0PM,videoPresentation,https://youtu.be/W3Vrrxo2w74,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1275/v-full-1275_Preview.mp4?token=s-3k7ce13wMP2CJ8tVZi79RhIyDe-RpGRBaPn6usyD4&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456319
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456319
@@ -3,4 +3,5 @@ Paper Preprint,http://arxiv.org/abs/2408.01991,paper
 Supplemental Material,https://osf.io/3v8wm/,other
 Preregistration,https://osf.io/h4cks,other
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1451.html,other
-Fast Forward Video,https://youtu.be/X9GOtQyXfx8,video
+Fast Forward Video,https://youtu.be/X9GOtQyXfx8,videoPresentation,https://youtu.be/7Y2cPfXGiAY,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1451/v-full-1451_Preview.mp4?token=vn2MF9S6BIWPnnQW9jdGn6mw5twlPZQJCJeUv_PSqLI&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456320
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456320
@@ -2,4 +2,5 @@ name,url,icon
 Paper Preprint,https://arxiv.org/abs/2407.00981,paper
 Supplemental Material,https://github.com/microsoft/VisEval,other
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1332.html,other
-Fast Forward Video,https://youtu.be/lKkg-pUufh8,video
+Fast Forward Video,https://youtu.be/lKkg-pUufh8,videoPresentation,https://youtu.be/d-eG7NRcrKg,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1332/v-full-1332_Preview.mp4?token=tbykaWmlhAAS8qHK-3sM9HAod8Q6W5G5TKF9TC0sT64&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456321
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456321
@@ -2,4 +2,5 @@ name,url,icon
 Paper Preprint,http://arxiv.org/pdf/2408.16308v1,paper
 Supplemental Material,"https://osf.io/pb8t3/  and  https://github.com/lpfeng11/AdaMotif,other
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1606.html,other
-Fast Forward Video,https://youtu.be/gWWaEplNEMQ,video
+Fast Forward Video,https://youtu.be/gWWaEplNEMQ,videoPresentation,https://youtu.be/uw_DXYjpu24,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1606/v-full-1606_Preview.mp4?token=XNAI--kxzKJbfnEWfEQn-z-dQs-XeCUps7OttO-Ri_8&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456322
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456322
@@ -2,4 +2,5 @@ name,url,icon
 Paper Preprint,http://arxiv.org/pdf/2408.04836v2,paper
 Supplemental Material,https://gitlab.kitware.com/vtk/vtk-m,other
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1705.html,other
-Fast Forward Video,https://youtu.be/_RvXzzJfjFA,video
+Fast Forward Video,https://youtu.be/_RvXzzJfjFA,videoPresentation,https://youtu.be/Pd3W5-EJRVg,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1705/v-full-1705_Preview.mp4?token=KRb7CIhbrASvEyQDGsuCalh0XjYtWrTtPA72tjD062g&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456323
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456323
@@ -2,4 +2,5 @@ name,url,icon
 Paper Preprint,https://arxiv.org/abs/2408.03681,paper
 Supplemental Material,https://jamesjacko.github.io/genii/,other
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1613.html,other
-Fast Forward Video,https://youtu.be/4GP7AtRD2y4,video
+Fast Forward Video,https://youtu.be/4GP7AtRD2y4,videoPresentation,https://youtu.be/55Jz0Cdvl1k,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1613/v-full-1613_Preview.mp4?token=Uhv0T5i2byoQIGD44Vxa9Jcd8h91FAHp0C8U8pLpvB4&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456324
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456324
@@ -1,4 +1,5 @@
 name,url,icon
 Paper Preprint,https://arxiv.org/abs/2407.15959,paper
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1140.html,other
-Fast Forward Video,https://youtu.be/ciCUI2ju3tM,video
+Fast Forward Video,https://youtu.be/ciCUI2ju3tM,videoPresentation,https://youtu.be/55Jz0Cdvl1k,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1140/v-full-1140_Preview.mp4?token=Oa5acEgF9yK70H6UaYyGjVl90iRXE9dQ_dGCjqjQ3x0&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456325
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456325
@@ -2,4 +2,5 @@ name,url,icon
 Paper Preprint,https://arxiv.org/abs/2407.14770,paper
 Supplemental Material,https://github.com/jianghr-shanghaitech/SLInterpreter-Demo,other
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1368.html,other
-Fast Forward Video,https://youtu.be/eaCCRPrMxk8,video
+Fast Forward Video,https://youtu.be/eaCCRPrMxk8,videoPresentation,https://youtu.be/w1Tud4nOruI,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1368/v-full-1368_Preview.mp4?token=2pjLZ8kfmwZTY5NRT1gcmw7TYjbBieYXXm59fK4BgU0&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456327
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456327
@@ -2,4 +2,5 @@ name,url,icon
 Paper Preprint,http://arxiv.org/abs/2407.13416,paper
 Supplemental Material,https://osf.io/8xrjm/,other
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1316.html,other
-Fast Forward Video,https://youtu.be/vydQsSgBECk,video
+Fast Forward Video,https://youtu.be/vydQsSgBECk,videoPresentation,https://youtu.be/GmSnZQ8onkA,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1316/v-full-1316_Preview.mp4?token=aom1JV67M5JX6eNDgcArCWIG3btpoAxnO5PPvGZrCZI&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456328
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456328
@@ -1,3 +1,4 @@
 name,url,icon
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1730.html,other
-Fast Forward Video,https://youtu.be/C0yhkKGlj7k,video
+Fast Forward Video,https://youtu.be/C0yhkKGlj7k,videoPresentation,https://youtu.be/HC69aABUJuc,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1730/v-full-1730_Preview.mp4?token=Op3_qrWX97c6NMeKmmpmOyBBKivPzJrkuUPEMAy2z2M&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456332
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456332
@@ -1,4 +1,5 @@
 name,url,icon
 Paper Preprint,http://arxiv.org/pdf/2408.05123v1,paper
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1351.html,other
-Fast Forward Video,https://youtu.be/IZil979U9UQ,video
+Fast Forward Video,https://youtu.be/IZil979U9UQ,videoPresentation,https://youtu.be/SOrXiceBb2g,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1351/v-full-1351_Preview.mp4?token=bIGHDjLkrgJQpolXS_FEYprMGOPhEwvYQLjlBgRYK6Y&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456334
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456334
@@ -1,4 +1,5 @@
 name,url,icon
 Paper Preprint,https://arxiv.org/abs/2407.17994,paper
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1394.html,other
-Fast Forward Video,https://youtu.be/zBwtliqYULc,video
+Fast Forward Video,https://youtu.be/zBwtliqYULc,videoPresentation,https://youtu.be/FLsXwoR_H8E,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1394/v-full-1394_Preview.mp4?token=CBABLCrD8Q-YwP3M7gFn4tKU58vJoBc0VguQ7DYvcRM&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456335
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456335
@@ -2,4 +2,5 @@ name,url,icon
 Paper Preprint,https://arxiv.org/abs/2408.03813,paper
 Supplemental Material,https://osf.io/8gpv2/,other
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1302.html,other
-Fast Forward Video,https://youtu.be/-xq224J5umc,video
+Fast Forward Video,https://youtu.be/-xq224J5umc,videoPresentation,https://youtu.be/w1Tud4nOruI,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1302/v-full-1302_Preview.mp4?token=X7Rtn5_FSND2OZ7n5tcNS3dGX4peJ_l1b467_T1gcoo&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456336
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456336
@@ -2,4 +2,5 @@ name,url,icon
 Paper Preprint,https://hal.science/hal-04664470/,paper
 Supplemental Material,https://datagarden-git.github.io/datagarden/,other
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1502.html,other
-Fast Forward Video,https://youtu.be/IFG97n_gi0g,video
+Fast Forward Video,https://youtu.be/IFG97n_gi0g,videoPresentation,https://youtu.be/FLsXwoR_H8E,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1502/v-full-1502_Preview.mp4?token=w4CD-laAbkqYIpzNABukxJTmJ15CNB136u4pl5pvCeg&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456337
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456337
@@ -1,4 +1,5 @@
 name,url,icon
 Paper Preprint,https://arxiv.org/abs/2406.09423,paper
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1793.html,other
-Fast Forward Video,https://youtu.be/TRMO8YUuSSs,video
+Fast Forward Video,https://youtu.be/TRMO8YUuSSs,videoPresentation,https://youtu.be/Pd3W5-EJRVg,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1793/v-full-1793_Preview.mp4?token=mq_GwqVoaX8VM0EBDuKWSvU8zRZEYMCZpPRYlndDs5E&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456338
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456338
@@ -2,4 +2,5 @@ name,url,icon
 Paper Preprint,https://arxiv.org/abs/2407.14100,paper
 Supplemental Material,https://github.com/YangL-04-20/ParamsDrag,other
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1427.html,other
-Fast Forward Video,https://youtu.be/qD2sZpl6UHU,video
+Fast Forward Video,https://youtu.be/qD2sZpl6UHU,videoPresentation,https://youtu.be/-VxwRlkinOQ,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1427/v-full-1427_Preview.mp4?token=QuVb7a5FWGuhagCSddIouToS9sigElvTzOsQLahtvBE&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456340
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456340
@@ -1,4 +1,5 @@
 name,url,icon
 Paper Preprint,https://arxiv.org/abs/2408.04874,paper
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1425.html,other
-Fast Forward Video,https://youtu.be/qzU1QLDM4zs,video
+Fast Forward Video,https://youtu.be/qzU1QLDM4zs,videoPresentation,https://youtu.be/I_s2xqsUD28,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1425/v-full-1425_Preview.mp4?token=k2gdCk90u5wFDpzx5zb2D4M_tSdgJgLIUBwsRlEFYB0&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456341
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456341
@@ -1,4 +1,5 @@
 name,url,icon
 Paper Preprint,http://arxiv.org/pdf/2407.11497v3,paper
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1594.html,other
-Fast Forward Video,https://youtu.be/4OD9F2xvtPk,video
+Fast Forward Video,https://youtu.be/4OD9F2xvtPk,videoPresentation,https://youtu.be/GmSnZQ8onkA,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1594/v-full-1594_Preview.mp4?token=B9Jdz8SGk1SHbPzpmdPFshIFsnyhUeDMu4Jk_yQSLvQ&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456342
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456342
@@ -1,4 +1,5 @@
 name,url,icon
 Paper Preprint,https://arxiv.org/abs/2408.00150,paper
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1391.html,other
-Fast Forward Video,https://youtu.be/TTUmK5WKV_w,video
+Fast Forward Video,https://youtu.be/TTUmK5WKV_w,videoPresentation,https://youtu.be/-VxwRlkinOQ,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1391/v-full-1391_Preview.mp4?token=ITGmgaQ31HqudY__3ys3icjyOy8ieyvto0Z2lDmm_8A&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456343
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456343
@@ -2,4 +2,5 @@ name,url,icon
 Paper Preprint,http://arxiv.org/abs/2407.20103,paper
 Supplemental Material,https://osf.io/tn6m2/,other
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1281.html,other
-Fast Forward Video,https://youtu.be/Uwwba1Z9EbE,video
+Fast Forward Video,https://youtu.be/Uwwba1Z9EbE,videoPresentation,https://youtu.be/3FAi9iPZPRA,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1281/v-full-1281_Preview.mp4?token=y9YINAlWfIcoFGqsDl8_Cv6p7SfGysnOf5tLybgHOTU&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456344
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456344
@@ -2,4 +2,5 @@ name,url,icon
 Paper Preprint,https://arxiv.org/abs/2408.03576,paper
 Supplemental Material,https://osf.io/h5awt/,other
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1726.html,other
-Fast Forward Video,https://youtu.be/WuNz1VKzPLY,video
+Fast Forward Video,https://youtu.be/WuNz1VKzPLY,videoPresentation,https://youtu.be/55Jz0Cdvl1k,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1726/v-full-1726_Preview.mp4?token=qLuJG8ZPdGGFSTym-fu41zzoGoT8LM1yYZ6-jU99qiA&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456345
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456345
@@ -2,4 +2,5 @@ name,url,icon
 Paper Preprint,http://arxiv.org/abs/2407.12399,paper
 Supplemental Material,https://github.com/MohamedKISSI/Code-Paper-A-Pratical-Solver-for-Scalar-Data-Topological-Simplification,other
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1461.html,other
-Fast Forward Video,https://youtu.be/PJ_tDek0d88,video
+Fast Forward Video,https://youtu.be/PJ_tDek0d88,videoPresentation,https://youtu.be/j1W-7oN5gGk,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1461/v-full-1461_Preview.mp4?token=8hD_BYjbZdeNNM6x4XqOfZp21w509Z-xWOKfOVEKzT0&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456346
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456346
@@ -2,4 +2,5 @@ name,url,icon
 Paper Preprint,https://arxiv.org/abs/2408.02679,paper
 Supplemental Material,https://github.com/mengjiefan/multi_outcome/tree/vis_rev_sub,other
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1693.html,other
-Fast Forward Video,https://youtu.be/bu5PgW9Q6Kg,video
+Fast Forward Video,https://youtu.be/bu5PgW9Q6Kg,videoPresentation,https://youtu.be/uw_DXYjpu24,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1693/v-full-1693_Preview.mp4?token=ovYGwzD9MYXQVpPzgVA8YPTLXY9HO1ombY8hfQ3Uh48&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456347
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456347
@@ -2,4 +2,5 @@ name,url,icon
 Paper Preprint,https://osf.io/preprints/osf/t5m3u,paper
 Supplemental Material,https://osf.io/6fbjp/,other
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1395.html,other
-Fast Forward Video,https://youtu.be/S6366DrJQTs,video
+Fast Forward Video,https://youtu.be/S6366DrJQTs,videoPresentation,https://youtu.be/NWNMgWnT7NM,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1395/v-full-1395_Preview.mp4?token=V1XLccn7O78RyqyQxzrfDBtx39_DAamtvybdh6UTnM0&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456348
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456348
@@ -1,4 +1,5 @@
 name,url,icon
 Supplemental Material,https://github.com/accessodu/GraphLite.git,other
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1917.html,other
-Fast Forward Video,https://youtu.be/2R4conY9Pfw,video
+Fast Forward Video,https://youtu.be/2R4conY9Pfw,videoPresentation,https://youtu.be/sO33xoUQ9fk,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1917/v-full-1917_Preview.mp4?token=MBZ8ifJtfXtnMfRB7H2bLh5bT5dInwre0HDdcTyarSE&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456349
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456349
@@ -1,4 +1,5 @@
 name,url,icon
 Supplemental Material,https://osf.io/5vq79,other
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1874.html,other
-Fast Forward Video,https://youtu.be/wIQnahaRsKk,video
+Fast Forward Video,https://youtu.be/wIQnahaRsKk,videoPresentation,https://youtu.be/cJNBh2zSTiU,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1874/v-full-1874_Preview.mp4?token=G85Efq1rI0eSTL1MK_drwz50PwtWDcSI-zBmJYnTLUE&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456350
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456350
@@ -1,4 +1,5 @@
 name,url,icon
 Paper Preprint,http://arxiv.org/pdf/2408.06845v2,paper
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1472.html,other
-Fast Forward Video,https://youtu.be/Y-lg3iu3-o4,video
+Fast Forward Video,https://youtu.be/Y-lg3iu3-o4,videoPresentation,https://youtu.be/NWNMgWnT7NM,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1472/v-full-1472_Preview.mp4?token=kwZ9vXZXTmgiZroZv-H25sDIQX0qQpBLBTsHkJ0-Xw8&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456351
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456351
@@ -1,4 +1,5 @@
 name,url,icon
 Paper Preprint,https://arxiv.org/abs/2408.04041,paper
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1487.html,other
-Fast Forward Video,https://youtu.be/c8cC1W9ucj8,video
+Fast Forward Video,https://youtu.be/c8cC1W9ucj8,videoPresentation,https://youtu.be/w1Tud4nOruI,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1487/v-full-1487_Preview.mp4?token=FQT1xLvgPUr_7zSaXHM2CKNTj1_d2c5nF6amiRsmBtY&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456352
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456352
@@ -2,4 +2,5 @@ name,url,icon
 Paper Preprint,https://arxiv.org/abs/2407.20735,paper
 Supplemental Material,https://responsive-vis.github.io/map-cheat-sheet/,other
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1393.html,other
-Fast Forward Video,https://youtu.be/mGAIwYY0AN4,video
+Fast Forward Video,https://youtu.be/mGAIwYY0AN4,videoPresentation,https://youtu.be/55Jz0Cdvl1k,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1393/v-full-1393_Preview.mp4?token=lGAUq2xdhP4kfeEG8qYsYRxSmjHdL97R3mzVkkDkGVI&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456353
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456353
@@ -2,4 +2,5 @@ name,url,icon
 Paper Preprint,https://arxiv.org/abs/2408.06139,paper
 Supplemental Material,https://urbantk.org/curio,other
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1830.html,other
-Fast Forward Video,https://youtu.be/phFXjrH7_ns,video
+Fast Forward Video,https://youtu.be/phFXjrH7_ns,videoPresentation,https://youtu.be/HC69aABUJuc,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1830/v-full-1830_Preview.mp4?token=PMw01OvmxRM3Dmn59e5pWrPncdeYM4gUN3dS9qUjibM&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456354
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456354
@@ -1,4 +1,5 @@
 name,url,icon
 Supplemental Material,https://github.com/PAIR-code/llm-comparator,other
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1326.html,other
-Fast Forward Video,https://youtu.be/DVHN9srNTkk,video
+Fast Forward Video,https://youtu.be/DVHN9srNTkk,videoPresentation,https://youtu.be/hEywiCiEJO0,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1326/v-full-1326_Preview.mp4?token=GYD8fWb2Fu3OrvKSiArk2XzM-LoMhtGk3WbHqeN0LKM&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456355
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456355
@@ -1,4 +1,5 @@
 name,url,icon
 Paper Preprint,http://arxiv.org/abs/2408.04769,paper
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1494.html,other
-Fast Forward Video,https://youtu.be/OzB9wNzCmRc,video
+Fast Forward Video,https://youtu.be/OzB9wNzCmRc,videoPresentation,https://youtu.be/j1W-7oN5gGk,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1494/v-full-1494_Preview.mp4?token=usx194xYVR8-djPko3ohF_0PYny_K5RbH2x0Fqx0ZFw&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456356
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456356
@@ -1,4 +1,5 @@
 name,url,icon
 Paper Preprint,https://arxiv.org/abs/2408.12607,paper
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1805.html,other
-Fast Forward Video,https://youtu.be/zGpaBxAqkHw,video
+Fast Forward Video,https://youtu.be/zGpaBxAqkHw,videoPresentation,https://youtu.be/0TNqponA2lk,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1805/v-full-1805_Preview.mp4?token=vbIksADqVloSgv_7CEcnLkzX0sf30vsoN5mp0KBDjH0&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456357
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456357
@@ -1,4 +1,5 @@
 name,url,icon
 Paper Preprint,http://arxiv.org/pdf/2407.19082v2,paper
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1866.html,other
-Fast Forward Video,https://youtu.be/Kx3B9acBnOw,video
+Fast Forward Video,https://youtu.be/Kx3B9acBnOw,videoPresentation,https://youtu.be/-VxwRlkinOQ,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1866/v-full-1866_Preview.mp4?token=JvYFoDniHtLPq0JNoRUiG6oNdGm3_ZCRaIqpCOhs9yY&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456358
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456358
@@ -1,4 +1,5 @@
 name,url,icon
 Paper Preprint,https://arxiv.org/abs/2408.04806,paper
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1522.html,other
-Fast Forward Video,https://youtu.be/Xw469H8JWP4,video
+Fast Forward Video,https://youtu.be/Xw469H8JWP4,videoPresentation,https://youtu.be/sO33xoUQ9fk,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1522/v-full-1522_Preview.mp4?token=SEEy97d0dqlKpk3cT4vIQZNToqbJOTSBwqAygXATai4&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456359
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456359
@@ -2,4 +2,5 @@ name,url,icon
 Paper Preprint,https://arxiv.org/abs/2306.06043,paper
 Supplemental Material,https://shorturl.at/bAGM1,other
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1295.html,other
-Fast Forward Video,https://youtu.be/UiheOlbONP0,video
+Fast Forward Video,https://youtu.be/UiheOlbONP0,videoPresentation,https://youtu.be/GmSnZQ8onkA,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1295/v-full-1295_Preview.mp4?token=_i10nu4OVfcDWUUNBh5WygxjQbR6zDtTaRFQ2SYbFSA&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456360
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456360
@@ -1,4 +1,5 @@
 name,url,icon
 Paper Preprint,https://doi.org/10.48550/arXiv.2407.16119,paper
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1708.html,other
-Fast Forward Video,https://youtu.be/vEf-mNcR5M0,video
+Fast Forward Video,https://youtu.be/vEf-mNcR5M0,videoPresentation,https://youtu.be/KgA-HGs0_4s,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1708/v-full-1708_Preview.mp4?token=RuwNr0_Oj-7iuGFhpcoszwyfx6b8OX43V7VsYW4Jp-I&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456361
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456361
@@ -2,4 +2,5 @@ name,url,icon
 Paper Preprint,https://doi.org/10.48550/arXiv.2407.18427,paper
 Supplemental Material,https://osf.io/ywjs4/,other
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1291.html,other
-Fast Forward Video,https://youtu.be/Hht8iAtJ40w,video
+Fast Forward Video,https://youtu.be/Hht8iAtJ40w,videoPresentation,https://youtu.be/gaAm2v-ENKA,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1291/v-full-1291_Preview.mp4?token=libWQ7VS7pdmjYQyKZ3-lnWX54SUtumA-g-Tno70Egk&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456363
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456363
@@ -2,4 +2,5 @@ name,url,icon
 Paper Preprint,https://arxiv.org/abs/2407.12423,paper
 Supplemental Material,https://github.com/CinderD/StuGPTViz_Supplemental,other
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1329.html,other
-Fast Forward Video,https://youtu.be/r4bxhQuXqIM,video
+Fast Forward Video,https://youtu.be/r4bxhQuXqIM,videoPresentation,https://youtu.be/w1Tud4nOruI,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1329/v-full-1329_Preview.mp4?token=3rbgGFvDtMShBC9lwJqoPby4KLpDPaQSfRuudFGzbmo&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456365
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456365
@@ -1,4 +1,5 @@
 name,url,icon
 Paper Preprint,http://arxiv.org/pdf/2409.07257v1,paper
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1632.html,other
-Fast Forward Video,https://youtu.be/RHAnJMEbOOQ,video
+Fast Forward Video,https://youtu.be/RHAnJMEbOOQ,videoPresentation,https://youtu.be/oBQXVSnxy5g,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1632/v-full-1632_Preview.mp4?token=NL73IBsAgaCsJAwcWrdzocAOZp8ABJQsqvlxLuVM_aE&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456367
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456367
@@ -1,4 +1,5 @@
 name,url,icon
 Paper Preprint,https://arxiv.org/abs/2407.19621,paper
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1746.html,other
-Fast Forward Video,https://youtu.be/kP6irewadAE,video
+Fast Forward Video,https://youtu.be/kP6irewadAE,videoPresentation,https://youtu.be/uw_DXYjpu24,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1746/v-full-1746_Preview.mp4?token=ZRuLy-4QoGhRaO17UYqa07iEi1dYdlexH3G8P14LWxU&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456368
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456368
@@ -5,4 +5,5 @@ Preregistration,https://osf.io/wmycx,other
 Preregistration,https://osf.io/3aty8,other
 Preregistration,https://osf.io/u3q8f,other
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1626.html,other
-Fast Forward Video,https://youtu.be/C-F1zT-UgsE,video
+Fast Forward Video,https://youtu.be/C-F1zT-UgsE,videoPresentation,https://youtu.be/sO33xoUQ9fk,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1626/v-full-1626_Preview.mp4?token=sK3xgzYvz9vy3e12YjM6EeAlIsksBkwUQRHAkZSg-e0&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456369
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456369
@@ -2,4 +2,5 @@ name,url,icon
 Paper Preprint,http://arxiv.org/pdf/2408.16078v1,paper
 Supplemental Material,https://github.com/VACLab/Co-op,other
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1258.html,other
-Fast Forward Video,https://youtu.be/xFxX4tX8KKM,video
+Fast Forward Video,https://youtu.be/xFxX4tX8KKM,videoPresentation,https://youtu.be/ESst2nxcXuA,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1258/v-full-1258_Preview.mp4?token=VYZkWSazuZO9S5NwEeptlwzOFMY2nnIEGDfaeGEKwyY&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456370
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456370
@@ -1,4 +1,5 @@
 name,url,icon
 Paper Preprint,https://osf.io/puxnf,paper
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1489.html,other
-Fast Forward Video,https://youtu.be/NOQMkUdisUc,video
+Fast Forward Video,https://youtu.be/NOQMkUdisUc,videoPresentation,https://youtu.be/H85FqQyR25U,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1489/v-full-1489_Preview.mp4?token=r1czoxoMzgDBguv0DW_GGZSz9mE6Bydk9Vp-An3d2Is&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456371
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456371
@@ -2,4 +2,5 @@ name,url,icon
 Paper Preprint,https://arxiv.org/pdf/2408.03274,paper
 Supplemental Material,https://github.com/apple/ml-compress-and-compare,other
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1142.html,other
-Fast Forward Video,https://youtu.be/5tS7HFn5W6Y,video
+Fast Forward Video,https://youtu.be/5tS7HFn5W6Y,videoPresentation,https://youtu.be/ESst2nxcXuA,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1142/v-full-1142_Preview.mp4?token=7bLX7TtYd-7Di9wJoeHtOTxkKehZFEDVJj3D4r93Uoo&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456372
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456372
@@ -1,4 +1,5 @@
 name,url,icon
 Paper Preprint,https://arxiv.org/abs/2407.12884,paper
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1599.html,other
-Fast Forward Video,https://youtu.be/htK9ytzwcDM,video
+Fast Forward Video,https://youtu.be/htK9ytzwcDM,videoPresentation,https://youtu.be/-VxwRlkinOQ,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1599/v-full-1599_Preview.mp4?token=9J85l_VJt9xibns9hdNhObpUAnkxe-sjC9TK-EcqYqE&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456373
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456373
@@ -1,4 +1,5 @@
 name,url,icon
 Paper Preprint,http://arxiv.org/pdf/2408.08992v3,paper
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1483.html,other
-Fast Forward Video,https://youtu.be/N4HpqmtLsDc,video
+Fast Forward Video,https://youtu.be/N4HpqmtLsDc,videoPresentation,https://youtu.be/cJNBh2zSTiU,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1483/v-full-1483_Preview.mp4?token=ytXWxPflKOx5y9augCJSEbmxJEVDgPNM0UIRemLg5Lo&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456375
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456375
@@ -1,3 +1,4 @@
 name,url,icon
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1363.html,other
-Fast Forward Video,https://youtu.be/TAD1E6fAMHU,video
+Fast Forward Video,https://youtu.be/TAD1E6fAMHU,videoPresentation,https://youtu.be/KgA-HGs0_4s,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1363/v-full-1363_Preview.mp4?token=0gXWRmcCMfl6L3ip3HixMsJXLSVigQa_bEzROzFp0No&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456377
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456377
@@ -2,4 +2,5 @@ name,url,icon
 Paper Preprint,https://osf.io/preprints/osf/z4s9d,paper
 Supplemental Material,https://osf.io/7xdq4/,other
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1137.html,other
-Fast Forward Video,https://youtu.be/84IvcxzBg7U,video
+Fast Forward Video,https://youtu.be/84IvcxzBg7U,videoPresentation,https://youtu.be/sO33xoUQ9fk,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1137/v-full-1137_Preview.mp4?token=MHGa74Psew6hZ1UpP2QgZ6SX6fMiKuMe3Ls2xjCriw0&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456378
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456378
@@ -1,4 +1,5 @@
 name,url,icon
 Paper Preprint,http://arxiv.org/pdf/2408.06837v2,paper
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1544.html,other
-Fast Forward Video,https://youtu.be/L_tj96AoLnI,video
+Fast Forward Video,https://youtu.be/L_tj96AoLnI,videoPresentation,https://youtu.be/hEywiCiEJO0,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1544/v-full-1544_Preview.mp4?token=xASKJTPbGCrNglAxnnLQVlf3Wmp5QMpznTvs0msc0MA&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456379
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456379
@@ -1,3 +1,4 @@
 name,url,icon
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1810.html,other
-Fast Forward Video,https://youtu.be/JP2jrdeR04g,video
+Fast Forward Video,https://youtu.be/JP2jrdeR04g,videoPresentation,https://youtu.be/GmSnZQ8onkA,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1810/v-full-1810_Preview.mp4?token=svlpWrXTXba_ADnrB67YdHrra2wvXxdOQlnNYeB_NlU&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456381
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456381
@@ -2,4 +2,5 @@ name,url,icon
 Paper Preprint,http://arxiv.org/pdf/2408.16077v1,paper
 Supplemental Material,https://osf.io/dfkv4/?view_only=f84ffbc28cdf45e5a3d68f2f1e9c8427,other
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1100.html,other
-Fast Forward Video,https://youtu.be/-9MypSwTv8w,video
+Fast Forward Video,https://youtu.be/-9MypSwTv8w,videoPresentation,https://youtu.be/rSvwf4L8jPc,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1100/v-full-1100_Preview.mp4?token=-tczNKjms6dku05m_c2tjjPtjHG0S_SDlRk3Z_2yHXI&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456384
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456384
@@ -1,4 +1,5 @@
 name,url,icon
 Supplemental Material,https://doi.org/10.5281/zenodo.12750719,other
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1574.html,other
-Fast Forward Video,https://youtu.be/uzDwMGgfoLE,video
+Fast Forward Video,https://youtu.be/uzDwMGgfoLE,videoPresentation,https://youtu.be/j1W-7oN5gGk,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1574/v-full-1574_Preview.mp4?token=1dzHZmqY0ScY43iHcq0r_TadN7TuEBg0fKQ4q1NmftE&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456386
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456386
@@ -2,4 +2,5 @@ name,url,icon
 Paper Preprint,https://arxiv.org/abs/2407.14742,paper
 Supplemental Material,https://osf.io/e4b5u/?view_only=68cc67c194c443b498bd2545ef551faa,other
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1595.html,other
-Fast Forward Video,https://youtu.be/RjtAd4XmMsU,video
+Fast Forward Video,https://youtu.be/RjtAd4XmMsU,videoPresentation,https://youtu.be/yBF6qqK_ASs,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1595/v-full-1595_Preview.mp4?token=toj6GxPoOhr1jLn6j9nD71SzjSzQTxHw6k3YcrcXjAo&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456387
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456387
@@ -1,4 +1,5 @@
 name,url,icon
 Paper Preprint,https://arxiv.org/abs/2407.12315,paper
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1603.html,other
-Fast Forward Video,https://youtu.be/oJrEG0FkEYw,video
+Fast Forward Video,https://youtu.be/oJrEG0FkEYw,videoPresentation,https://youtu.be/H85FqQyR25U,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1603/v-full-1603_Preview.mp4?token=U2SeRph0CmCty6EkL1awqGasK-mUH3IZYpTsKqatksE&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456389
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456389
@@ -2,4 +2,5 @@ name,url,icon
 Paper Preprint,http://arxiv.org/pdf/2408.06601v1,paper
 Supplemental Material,https://github.com/bitvis2021/HiRegEx,other
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1831.html,other
-Fast Forward Video,https://youtu.be/7q67dSgbZCI,video
+Fast Forward Video,https://youtu.be/7q67dSgbZCI,videoPresentation,https://youtu.be/uw_DXYjpu24,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1831/v-full-1831_Preview.mp4?token=n9QVeFNmeHdmGxNyALHyOSelyM2wK96nkpNFEk5JK20&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456391
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456391
@@ -1,4 +1,5 @@
 name,url,icon
 Paper Preprint,http://arxiv.org/pdf/2404.07386v2,paper
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1568.html,other
-Fast Forward Video,https://youtu.be/tH3ik7KCn0A,video
+Fast Forward Video,https://youtu.be/tH3ik7KCn0A,videoPresentation,https://youtu.be/oBQXVSnxy5g,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1568/v-full-1568_Preview.mp4?token=4rHbL9zypOPcv4QmTnYnprbl4RS8YStj6BPAK4rizBA&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456392
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456392
@@ -1,3 +1,4 @@
 name,url,icon
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1681.html,other
-Fast Forward Video,https://youtu.be/qZcYIS995YE,video
+Fast Forward Video,https://youtu.be/qZcYIS995YE,videoPresentation,https://youtu.be/vNaxXisbG4Y,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1681/v-full-1681_Preview.mp4?token=3S6TVYPNim5-H1pVaXrfj9MMJ5GUV-fnBLAlWj5Cu9Y&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456393
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456393
@@ -1,4 +1,5 @@
 name,url,icon
 Paper Preprint,https://arxiv.org/abs/2407.18015v1,paper
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1277.html,other
-Fast Forward Video,https://youtu.be/kaB1IpYiCCU,video
+Fast Forward Video,https://youtu.be/kaB1IpYiCCU,videoPresentation,https://youtu.be/j1W-7oN5gGk,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1277/v-full-1277_Preview.mp4?token=FXTjHbPuB0h34s6PnN3eMIszxbIPGY02V9mpQFmdpQM&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456394
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456394
@@ -2,4 +2,5 @@ name,url,icon
 Paper Preprint,http://arxiv.org/abs/2408.03641,paper
 Supplemental Material,https://github.com/marinaevers/segmentation-projection,other
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1612.html,other
-Fast Forward Video,https://youtu.be/91i3yDeIi38,video
+Fast Forward Video,https://youtu.be/91i3yDeIi38,videoPresentation,https://youtu.be/oBQXVSnxy5g,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1612/v-full-1612_Preview.mp4?token=EUgVBfrye42pazKDBfY0V5t7uuwIUzDQgiF4rdtXwRw&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456395
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456395
@@ -2,4 +2,5 @@ name,url,icon
 Paper Preprint,https://arxiv.org/abs/2404.05879,paper
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1880.html,other
 Fast Forward Video,https://youtu.be/5x_3_xJ0xKc,video
-Source Code and Data,https://osf.io/2n8dy/,code
+Source Code and Data,https://osf.io/2n8dy/,codePresentation,https://youtu.be/d-eG7NRcrKg,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1880/v-full-1880_Preview.mp4?token=g3OGwgih9TpwR_wddxmFWU_U55zB38PzucsWWRcn5iY&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456398
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456398
@@ -1,4 +1,5 @@
 name,url,icon
 Paper Preprint,https://arxiv.org/abs/2407.12192,paper
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1474.html,other
-Fast Forward Video,https://youtu.be/H4QzA6XFPFs,video
+Fast Forward Video,https://youtu.be/H4QzA6XFPFs,videoPresentation,https://youtu.be/TkBPnodArzQ,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1474/v-full-1474_Preview.mp4?token=8Hfco-UGUujuyZG-6mVef9LTBGpU15pw5Etlf-Jd148&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456401
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456401
@@ -4,3 +4,5 @@ Supplemental Material,https://gitlab.fi.muni.cz/visitlab/loopgrafter-frontend-1.
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1597.html,other
 Fast Forward Video,https://youtu.be/TjB6UTqQMHc,video
 Project Website with Demo,https://loschmidt.chemi.muni.cz/loopgrafter,project_website
+Presentation,https://youtu.be/Za3820yadmE,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1597/v-full-1597_Preview.mp4?token=dqG5O6MdgNjF_Kd8T_AnVvxZsuj2zZfem9zMErGW_OM&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456402
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456402
@@ -2,4 +2,5 @@ name,url,icon
 Paper Preprint,http://arxiv.org/pdf/2408.16702v1,paper
 Supplemental Material,https://mucollective.github.io/vmc/,other
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1309.html,other
-Fast Forward Video,https://youtu.be/OqNLDTwT7DY,video
+Fast Forward Video,https://youtu.be/OqNLDTwT7DY,videoPresentation,https://youtu.be/ESst2nxcXuA,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1309/v-full-1309_Preview.mp4?token=_d8vt5BoHauPleUOak6d14mJ7U4ji1klBajeDY0bUv0&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456403
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456403
@@ -3,4 +3,5 @@ Paper Preprint,https://doi.org/10.31219/osf.io/2t3sc,paper
 Supplemental Material,https://osf.io/jfg3h/?view_only=f064cff189c4440299a3c3b10ddab232,other
 Preregistration,https://osf.io/b67xu?view_only=b9cc56507fc54ae399d0f468d53474ed,other
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1288.html,other
-Fast Forward Video,https://youtu.be/U-KVskuEvz8,video
+Fast Forward Video,https://youtu.be/U-KVskuEvz8,videoPresentation,https://youtu.be/gaAm2v-ENKA,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1288/v-full-1288_Preview.mp4?token=WrBIX_ELfQf5Wq5HyVgAdJ-Km4gCT2hW7QnwqnMe4og&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456404
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456404
@@ -2,4 +2,5 @@ name,url,icon
 Paper Preprint,https://arxiv.org/abs/2404.02465,paper
 Supplemental Material,https://osf.io/5tx4q/,other
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1533.html,other
-Fast Forward Video,https://youtu.be/ptmTip8km8k,video
+Fast Forward Video,https://youtu.be/ptmTip8km8k,videoPresentation,https://youtu.be/Za3820yadmE,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1533/v-full-1533_Preview.mp4?token=V8OcgojfOjgG9iatxgIF8UGOAImc5hoAlvO4BVA5RCg&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456405
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456405
@@ -2,4 +2,5 @@ name,url,icon
 Paper Preprint,http://arxiv.org/pdf/2408.04799v1,paper
 Supplemental Material,https://osf.io/8c95v/,other
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1325.html,other
-Fast Forward Video,https://youtu.be/pY3yFbMe5RE,video
+Fast Forward Video,https://youtu.be/pY3yFbMe5RE,videoPresentation,https://youtu.be/7Y2cPfXGiAY,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1325/v-full-1325_Preview.mp4?token=znV_u6YW7G-s5ppYwiYo4wWNrKPrsIIJxfTiurV5PC8&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456406
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456406
@@ -1,4 +1,5 @@
 name,url,icon
 Paper Preprint,https://osf.io/preprints/osf/axy82,paper
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1615.html,other
-Fast Forward Video,https://youtu.be/wVBlWgy1Gd8,video
+Fast Forward Video,https://youtu.be/wVBlWgy1Gd8,videoPresentation,https://youtu.be/Za3820yadmE,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1615/v-full-1615_Preview.mp4?token=3texbGZWm2_V72b-KPt0rGFoMxv76gsFkNDOwCnQ1FE&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456510
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456510
@@ -2,4 +2,5 @@ name,url,icon
 Paper Preprint,http://arxiv.org/pdf/2408.04752v1,paper
 Supplemental Material,https://osf.io/bkjsc/?view_only=b95871b8c4ae497ab9b6cb565e28edf5,other
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1642.html,other
-Fast Forward Video,https://youtu.be/4WP9eGQ_hwI,video
+Fast Forward Video,https://youtu.be/4WP9eGQ_hwI,videoPresentation,https://youtu.be/M8JHVCnERRk,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1642/v-full-1642_Preview.mp4?token=6EC8R0dh9lTx_Yo63GE8xfzo74rMtLPiKE-sX05YXik&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2024.3456598
+++ b/public/data/paperLinks/10.1109/TVCG.2024.3456598
@@ -1,4 +1,5 @@
 name,url,icon
 Paper Preprint,https://osf.io/preprints/osf/pjcn4,paper
 IEEE VIS Conference Page,https://ieeevis.org/year/2024/program/paper_v-full-1504.html,other
-Fast Forward Video,https://youtu.be/IL0N2WMISlg,video
+Fast Forward Video,https://youtu.be/IL0N2WMISlg,videoPresentation,https://youtu.be/TkBPnodArzQ,video
+Session Recording,https://ieeevis-uploads.b-cdn.net/vis24/v-full/v-full-1504/v-full-1504_Preview.mp4?token=jFGXnF-YKBBGg2rqeIRI8fjQS13h17VKJfyxu12UsP8&expires=1730433600,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3633827
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3633827
@@ -2,4 +2,5 @@ name,url,icon
 Paper Preprint,https://osf.io/preprints/osf/ypez4,paper
 Supplemental Material,https://osf.io/bdet6/,other
 Preregistration,https://osf.io/5xe8a,other
-IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_5cf45946-05e6-4d9c-876e-abeacdf5b8e1.html,other
+IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_5cf45946-05e6-4d9c-876e-abeacdf5b8e1.html,otherPresentation,https://youtu.be/gvbjZE1CgLQ,video
+Session Recording,https://youtu.be/gvbjZE1CgLQ,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3633829
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3633829
@@ -4,4 +4,5 @@ Supplemental Material,https://osf.io/gfqc3/,other
 Preregistration 1,https://osf.io/t65su,other
 Preregistration 2,https://osf.io/mzcky,other
 Preregistration 3,https://osf.io/myt7g,other
-IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_72c11016-caee-44a4-82cf-1939cf5d21d3.html,other
+IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_72c11016-caee-44a4-82cf-1939cf5d21d3.html,otherPresentation,https://youtu.be/3SfIEPcGmf0,video
+Session Recording,https://youtu.be/3SfIEPcGmf0,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3633835
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3633835
@@ -2,3 +2,5 @@ name,url,icon
 Paper Preprint,https://shape.stanford.edu/research/TempoSonification/Fan25PerceivingSlopeAndAccelerationVariableTempoSamplingSonification.pdf,paper
 Supplemental Material,https://osf.io/a4cth/?view_only=784965f9e9f64a3ea720cf53ff241481,other
 IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_9e3dfe2c-bbe4-4431-ae8b-1ee64a399c8b.html,other
+Presentation,https://youtu.be/M8ysk79s5d8,video
+Session Recording,https://youtu.be/M8ysk79s5d8,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3633839
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3633839
@@ -1,2 +1,3 @@
 name,url,icon
-IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_bf2f93ab-ab67-4a81-8726-6819e84553be.html,other
+IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_bf2f93ab-ab67-4a81-8726-6819e84553be.html,otherPresentation,https://youtu.be/eNFqK9YEju4,video
+Session Recording,https://youtu.be/eNFqK9YEju4,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3633868
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3633868
@@ -1,4 +1,5 @@
 name,url,icon
 Paper Preprint,https://vc.cs.ovgu.de/assets/publications/2025/Friesecke_2025_VIS.pdf,paper
 Supplemental Material,https://github.com/lfriesecke/uncertainty-aware-pca-revisited,other
-IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_367cd3fe-b8ff-4bee-bd9f-ae8e51feeb9e.html,other
+IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_367cd3fe-b8ff-4bee-bd9f-ae8e51feeb9e.html,otherPresentation,https://youtu.be/gvbjZE1CgLQ,video
+Session Recording,https://youtu.be/gvbjZE1CgLQ,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3633869
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3633869
@@ -2,3 +2,5 @@ name,url,icon
 Paper Preprint,https://osf.io/preprints/osf/qtsak_v2?view_only=,paper
 Website,https://hdvis.github.io,project_website
 IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_32bd145e-06bf-411a-af2e-109192108a7e.html,other
+Presentation,https://youtu.be/zLchh59XyM4,video
+Session Recording,https://youtu.be/zLchh59XyM4,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3633870
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3633870
@@ -1,3 +1,4 @@
 name,url,icon
 Paper Preprint,https://arxiv.org/abs/2507.19870,paper
-IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_a79b8861-5ff1-41ab-ab84-c564496de8de.html,other
+IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_a79b8861-5ff1-41ab-ab84-c564496de8de.html,otherPresentation,https://youtu.be/LajPfGQe32k,video
+Session Recording,https://youtu.be/LajPfGQe32k,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3633872
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3633872
@@ -1,3 +1,4 @@
 name,url,icon
 Paper Preprint,https://arxiv.org/abs/2507.17024,paper
-IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_4cf2c4a7-98c7-4d49-a5c2-410ecde134cb.html,other
+IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_4cf2c4a7-98c7-4d49-a5c2-410ecde134cb.html,otherPresentation,https://youtu.be/zLchh59XyM4,video
+Session Recording,https://youtu.be/zLchh59XyM4,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3633874
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3633874
@@ -4,3 +4,5 @@ Supplemental Material,https://osf.io/9dwgq/,other
 Preregistration,https://osf.io/uhq68,other
 Website,https://vdl.sci.utah.edu/tactile-charts/,project_website
 IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_055a075f-b15e-43ec-becb-cc09ad944d2c.html,other
+Presentation,https://youtu.be/3SfIEPcGmf0,video
+Session Recording,https://youtu.be/3SfIEPcGmf0,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3633875
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3633875
@@ -1,3 +1,4 @@
 name,url,icon
 Paper Preprint,https://arxiv.org/abs/2508.00428,paper
-IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_84ef8d69-bdba-43e8-a078-ae651a3de164.html,other
+IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_84ef8d69-bdba-43e8-a078-ae651a3de164.html,otherPresentation,https://youtu.be/zLchh59XyM4,video
+Session Recording,https://youtu.be/zLchh59XyM4,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3633882
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3633882
@@ -2,3 +2,5 @@ name,url,icon
 Paper Preprint,https://arxiv.org/pdf/2507.18972,paper
 Code,https://github.com/GromitC/TiVy,code
 IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_8347663a-7e88-43e2-a557-e7b2179fd4e5.html,other
+Presentation,https://youtu.be/3SfIEPcGmf0,video
+Session Recording,https://youtu.be/3SfIEPcGmf0,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3633884
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3633884
@@ -3,3 +3,5 @@ Paper Preprint,https://arxiv.org/abs/2508.04679,paper
 Code,https://github.com/vhcailab/MisVisFix,code
 Website,http://167.71.222.168/,project_webste
 IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_e7cc7c10-4310-4753-b586-467106cdc883.html,other
+Presentation,https://youtu.be/Ga7NSmKd54M,video
+Session Recording,https://youtu.be/Ga7NSmKd54M,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3633887
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3633887
@@ -1,3 +1,4 @@
 name,url,icon
 Paper Preprint,https://arxiv.org/abs/2507.17209,paper
-IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_c06df49a-9aa2-40f9-94b9-23789ec137b8.html,other
+IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_c06df49a-9aa2-40f9-94b9-23789ec137b8.html,otherPresentation,https://youtu.be/zLchh59XyM4,video
+Session Recording,https://youtu.be/zLchh59XyM4,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3633888
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3633888
@@ -3,3 +3,5 @@ Paper Preprint,https://arxiv.org/abs/2507.12621,paper
 Code,https://github.com/KuangshiAi/nli4volvis,code
 Website,https://nli4volvis.github.io/,project_website
 IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_d22e24df-9562-498b-96d4-e9b19056c72d.html,other
+Presentation,https://youtu.be/eNFqK9YEju4,video
+Session Recording,https://youtu.be/eNFqK9YEju4,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3633893
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3633893
@@ -1,2 +1,3 @@
 name,url,icon
-IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_9af6703f-fc27-4be6-a995-f84e8091b517.html,other
+IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_9af6703f-fc27-4be6-a995-f84e8091b517.html,otherPresentation,https://youtu.be/mHta4w5FJQg,video
+Session Recording,https://youtu.be/mHta4w5FJQg,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3633894
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3633894
@@ -1,3 +1,4 @@
 name,url,icon
 Paper Preprint,https://arxiv.org/abs/2507.17174,paper
-IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_28a61ed9-3f15-4835-a688-e72b1fd6fa0c.html,other
+IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_28a61ed9-3f15-4835-a688-e72b1fd6fa0c.html,otherPresentation,https://youtu.be/gvbjZE1CgLQ,video
+Session Recording,https://youtu.be/gvbjZE1CgLQ,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3633896
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3633896
@@ -7,3 +7,5 @@ Preregistration 3,https://osf.io/t6gp2,other
 ReVISit Homepage,revisit.dev,project_website
 Replication Studies,revisit.dev/replication-studies,project_website
 IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_ebdd5b65-b5cb-4d4b-bd78-92ff8cc2f243.html,other
+Presentation,https://youtu.be/3EozS40EBjc,video
+Session Recording,https://youtu.be/3EozS40EBjc,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3633897
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3633897
@@ -1,3 +1,4 @@
 name,url,icon
 Paper Preprint,https://arxiv.org/abs/2508.00424,paper
-IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_c663a254-dd80-4021-88aa-f0840fc3024e.html,other
+IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_c663a254-dd80-4021-88aa-f0840fc3024e.html,otherPresentation,https://youtu.be/-Il9UvlqnNA,video
+Session Recording,https://youtu.be/-Il9UvlqnNA,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3633901
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3633901
@@ -2,3 +2,5 @@ name,url,icon
 Paper Preprint,https://arxiv.org/abs/2508.01240,paper
 Code,https://github.com/jtchen2k/relmap/,code
 IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_10233019-3fcc-4f01-b478-96b0ec01cf29.html,other
+Presentation,https://youtu.be/-Il9UvlqnNA,video
+Session Recording,https://youtu.be/-Il9UvlqnNA,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3633904
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3633904
@@ -2,3 +2,5 @@ name,url,icon
 Paper Preprint,https://arxiv.org/abs/2507.14685,paper
 Website,http://bit.ly/3IyEUI6,project_website
 IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_29b8a92c-ef97-44df-b315-a903fe54fa53.html,other
+Presentation,https://youtu.be/-Il9UvlqnNA,video
+Session Recording,https://youtu.be/-Il9UvlqnNA,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3633908
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3633908
@@ -2,3 +2,5 @@ name,url,icon
 Supplemental Material,https://github.com/Guozihengwww/PixelatedScatter,other
 Website,https://guozihengwww.github.io/PixelatedScatter-Demo,project_website
 IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_76560e50-f8e7-446f-943e-2ba7ff188c86.html,other
+Presentation,https://youtu.be/Ga7NSmKd54M,video
+Session Recording,https://youtu.be/Ga7NSmKd54M,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3633909
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3633909
@@ -1,4 +1,5 @@
 name,url,icon
 Paper Preprint,https://arxiv.org/abs/2508.02639,paper
 Supplemental Material,https://osf.io/z7ae2/,other
-IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_625a86de-1529-4724-8869-f081c7776f88.html,other
+IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_625a86de-1529-4724-8869-f081c7776f88.html,otherPresentation,https://youtu.be/3SfIEPcGmf0,video
+Session Recording,https://youtu.be/3SfIEPcGmf0,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3633910
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3633910
@@ -1,2 +1,3 @@
 name,url,icon
-IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_f53bf658-7b1b-4417-9c0c-0b74e7455702.html,other
+IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_f53bf658-7b1b-4417-9c0c-0b74e7455702.html,otherPresentation,https://youtu.be/nkeAR0PgfSw,video
+Session Recording,https://youtu.be/nkeAR0PgfSw,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3633911
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3633911
@@ -1,3 +1,4 @@
 name,url,icon
 Supplemental Material,https://osf.io/bhn6e/?view_only=6a130b6323364a1db514a3df45b94647,other
-IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_6c986f26-eabe-4109-b6ab-7ba4c489451d.html,other
+IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_6c986f26-eabe-4109-b6ab-7ba4c489451d.html,otherPresentation,https://youtu.be/nkeAR0PgfSw,video
+Session Recording,https://youtu.be/nkeAR0PgfSw,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3633912
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3633912
@@ -2,3 +2,5 @@ name,url,icon
 Paper Preprint,https://arxiv.org/abs/2507.19988,paper
 Code,https://github.com/vizlab-kobe/tulca,code
 IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_b5fec96f-039e-4af2-93d6-898b9a2caece.html,other
+Presentation,https://youtu.be/LajPfGQe32k,video
+Session Recording,https://youtu.be/LajPfGQe32k,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3634225
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3634225
@@ -4,4 +4,5 @@ Supplemental Material,https://osf.io/k45es/,other
 Experiment 1,https://osf.io/2d3hm,other
 Experiment 2,https://osf.io/a6hnv,other
 Experiment 3,https://osf.io/4jpdz,other
-IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_cdeb2b03-68fd-4816-8611-544145e35ba2.html,other
+IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_cdeb2b03-68fd-4816-8611-544145e35ba2.html,otherPresentation,https://youtu.be/v-iY-PKyXHs,video
+Session Recording,https://youtu.be/v-iY-PKyXHs,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3634232
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3634232
@@ -1,4 +1,5 @@
 name,url,icon
 Paper Preprint,https://arxiv.org/abs/2508.06117,paper
 Supplemental Material,https://doi.org/10.18419/DARUS-5166,other
-IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_18f5b9fb-e80f-415d-a701-6c7256d9711b.html,other
+IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_18f5b9fb-e80f-415d-a701-6c7256d9711b.html,otherPresentation,https://youtu.be/S3LGLxyblpM,video
+Session Recording,https://youtu.be/S3LGLxyblpM,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3634234
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3634234
@@ -3,3 +3,5 @@ Paper Preprint,https://arxiv.org/abs/2507.11999,paper
 Code,https://github.com/Selvalim/VGQ-front,code
 Website,https://wenxiaolin.com/_pages/envisage.html,project_website
 IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_ae49090b-23a7-453b-8d5d-eb0ad8893a08.html,other
+Presentation,https://youtu.be/zH5jvaUZHGk,video
+Session Recording,https://youtu.be/zH5jvaUZHGk,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3634243
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3634243
@@ -1,2 +1,3 @@
 name,url,icon
-IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_b00813fe-c0fb-4bdb-8040-b6e338088247.html,other
+IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_b00813fe-c0fb-4bdb-8040-b6e338088247.html,otherPresentation,https://youtu.be/gHCENa3C9X4,video
+Session Recording,https://youtu.be/gHCENa3C9X4,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3634245
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3634245
@@ -1,4 +1,5 @@
 name,url,icon
 Paper Preprint,https://arxiv.org/abs/2508.00140,paper
 Supplemental Material,https://osf.io/c87xm/?view_only=31dfc1f2a7624f5cb20b0f07d3730df3,other
-IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_1b3b1b15-e378-4c65-8984-717a7f7baa3a.html,other
+IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_1b3b1b15-e378-4c65-8984-717a7f7baa3a.html,otherPresentation,https://youtu.be/h8CsAxh4LWg,video
+Session Recording,https://youtu.be/h8CsAxh4LWg,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3634249
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3634249
@@ -1,3 +1,4 @@
 name,url,icon
 Paper Preprint,https://arxiv.org/pdf/2508.04650v1,paper
-IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_9942014b-e0f8-4cae-9b2a-81167d226c7b.html,other
+IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_9942014b-e0f8-4cae-9b2a-81167d226c7b.html,otherPresentation,https://youtu.be/h8CsAxh4LWg,video
+Session Recording,https://youtu.be/h8CsAxh4LWg,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3634250
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3634250
@@ -2,3 +2,5 @@ name,url,icon
 Supplemental Material,https://github.com/starfish-graphics/gofish-graphics,other
 Website,https://gofish.graphics/,project_website
 IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_12e7281f-5e70-4d16-a9a0-a87a0d46df5c.html,other
+Presentation,https://youtu.be/S3LGLxyblpM,video
+Session Recording,https://youtu.be/S3LGLxyblpM,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3634254
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3634254
@@ -1,2 +1,3 @@
 name,url,icon
-IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_544233de-86be-4bc4-ab7e-2e5de7d366b2.html,other
+IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_544233de-86be-4bc4-ab7e-2e5de7d366b2.html,otherPresentation,https://youtu.be/gHCENa3C9X4,video
+Session Recording,https://youtu.be/gHCENa3C9X4,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3634255
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3634255
@@ -1,4 +1,5 @@
 name,url,icon
 Paper Preprint,https://osf.io/preprints/osf/eyw2r_v1,paper
 Supplemental Material,https://osf.io/t9jhu/,other
-IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_2b91d1cf-ebf6-46b2-9cbc-cc51da3a56ed.html,other
+IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_2b91d1cf-ebf6-46b2-9cbc-cc51da3a56ed.html,otherPresentation,https://youtu.be/v-iY-PKyXHs,video
+Session Recording,https://youtu.be/v-iY-PKyXHs,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3634257
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3634257
@@ -1,2 +1,3 @@
 name,url,icon
-IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_e8ed00a7-2d3b-46b8-9edd-6853dd9c2f8c.html,other
+IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_e8ed00a7-2d3b-46b8-9edd-6853dd9c2f8c.html,otherPresentation,https://youtu.be/h8CsAxh4LWg,video
+Session Recording,https://youtu.be/h8CsAxh4LWg,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3634260
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3634260
@@ -2,3 +2,5 @@ name,url,icon
 Paper Preprint,https://arxiv.org/abs/2507.22665,paper
 Code,https://github.com/maxie12/RandomForestVis,code
 IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_d3492f20-d356-4c55-992d-dbc0fa0fe0af.html,other
+Presentation,https://youtu.be/h8CsAxh4LWg,video
+Session Recording,https://youtu.be/h8CsAxh4LWg,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3634261
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3634261
@@ -1,3 +1,4 @@
 name,url,icon
 Supplemental Material,https://osf.io/ymucn/,other
-IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_093872c4-bec7-4c27-bb8e-c89465a4381b.html,other
+IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_093872c4-bec7-4c27-bb8e-c89465a4381b.html,otherPresentation,https://youtu.be/gHCENa3C9X4,video
+Session Recording,https://youtu.be/gHCENa3C9X4,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3634263
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3634263
@@ -3,3 +3,5 @@ Paper Preprint,https://arxiv.org/abs/2410.12268,paper
 Supplemental Material,https://osf.io/962xc/?view_only=adbb315fd8794f6dac6b9625d385900f,other
 Website,https://visanatomy.github.io/,project_website
 IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_7ecd3f2d-f7b0-4b86-aa66-248cc17c0720.html,other
+Presentation,https://youtu.be/S3LGLxyblpM,video
+Session Recording,https://youtu.be/S3LGLxyblpM,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3634265
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3634265
@@ -1,3 +1,4 @@
 name,url,icon
 Paper Preprint,https://arxiv.org/abs/2508.06772,paper
-IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_f9fb5a2a-c9bd-48f5-b5be-8a75e1b77b02.html,other
+IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_f9fb5a2a-c9bd-48f5-b5be-8a75e1b77b02.html,otherPresentation,https://youtu.be/v-iY-PKyXHs,video
+Session Recording,https://youtu.be/v-iY-PKyXHs,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3634266
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3634266
@@ -3,3 +3,5 @@ Paper Preprint,https://osf.io/preprints/osf/5d9q6_v1,paper
 Supplemental Material,https://osf.io/f8s3g/?view_only=7e2df9109dfd4e6c85b89ed828320843,other
 Website,https://biofabric.dbvis.de/motifs/,project_webste
 IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_e14aa8da-3794-45ba-9dd7-5e0ced3449c7.html,other
+Presentation,https://youtu.be/zH5jvaUZHGk,video
+Session Recording,https://youtu.be/zH5jvaUZHGk,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3634629
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3634629
@@ -2,3 +2,5 @@ name,url,icon
 Paper Preprint,https://arxiv.org/abs/2507.14482/,paper
 Website,https://debate.datavizu.app/,project_website
 IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_da138859-6a6c-4df2-813b-6a70e20d04a1.html,other
+Presentation,https://youtu.be/fkfdha6pCeI,video
+Session Recording,https://youtu.be/fkfdha6pCeI,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3634630
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3634630
@@ -1,3 +1,4 @@
 name,url,icon
 Supplemental Material,https://osf.io/4nhtf/?view_only=b5168623250a44aa826ab027df42d87b,other
-IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_1e9e6140-6939-402f-8781-8420814824be.html,other
+IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_1e9e6140-6939-402f-8781-8420814824be.html,otherPresentation,https://youtu.be/v-iY-PKyXHs,video
+Session Recording,https://youtu.be/v-iY-PKyXHs,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3634631
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3634631
@@ -1,3 +1,5 @@
 name,url,icon
 Website,https://runningwithdata.github.io/,project_website
 IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_54daa89a-c0e5-4d1e-9891-4ce10711d2f9.html,other
+Presentation,https://youtu.be/6hTTrGMsPK8,video
+Session Recording,https://youtu.be/6hTTrGMsPK8,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3634632
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3634632
@@ -1,4 +1,5 @@
 name,url,icon
 Paper Preprint,https://arxiv.org/abs/2507.12334,paper
 Supplemental Material,https://osf.io/swqfc/,other
-IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_9188996c-0f8f-420b-95eb-1cf466e3fa0d.html,other
+IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_9188996c-0f8f-420b-95eb-1cf466e3fa0d.html,otherPresentation,https://youtu.be/v-iY-PKyXHs,video
+Session Recording,https://youtu.be/v-iY-PKyXHs,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3634633
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3634633
@@ -1,2 +1,3 @@
 name,url,icon
-IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_e61c0f73-21a5-4e16-bdb6-4038e74770ae.html,other
+IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_e61c0f73-21a5-4e16-bdb6-4038e74770ae.html,otherPresentation,https://youtu.be/fkfdha6pCeI,video
+Session Recording,https://youtu.be/fkfdha6pCeI,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3634634
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3634634
@@ -2,3 +2,5 @@ name,url,icon
 Paper Preprint,https://arxiv.org/abs/2507.19718,paper
 Website,https://dbauer15.github.io/papers/gscache/,project_website
 IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_99d47ba0-22e8-4d68-9484-346e6fc722b8.html,other
+Presentation,https://youtu.be/7jlWgTDmDL8,video
+Session Recording,https://youtu.be/7jlWgTDmDL8,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3634635
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3634635
@@ -1,3 +1,4 @@
 name,url,icon
 Paper Preprint,https://arxiv.org/abs/2507.17734,paper
-IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_30cf9291-b159-4a33-95bd-47f194b893a0.html,other
+IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_30cf9291-b159-4a33-95bd-47f194b893a0.html,otherPresentation,https://youtu.be/JQEgOnSg18o,video
+Session Recording,https://youtu.be/JQEgOnSg18o,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3634636
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3634636
@@ -1,3 +1,4 @@
 name,url,icon
 Paper Preprint,https://arxiv.org/abs/2504.03205,paper
-IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_981234e2-bdbe-42ef-863d-00d6ea28561d.html,other
+IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_981234e2-bdbe-42ef-863d-00d6ea28561d.html,otherPresentation,https://youtu.be/wUoqSN_s3tw,video
+Session Recording,https://youtu.be/wUoqSN_s3tw,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3634637
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3634637
@@ -1,4 +1,5 @@
 name,url,icon
 Paper Preprint,https://arxiv.org/abs/2507.15230,paper
 Supplemental Material,https://osf.io/zxm4w,other
-IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_5cec6278-7356-4658-8125-0dc6b65f8b08.html,other
+IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_5cec6278-7356-4658-8125-0dc6b65f8b08.html,otherPresentation,https://youtu.be/wUoqSN_s3tw,video
+Session Recording,https://youtu.be/wUoqSN_s3tw,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3634638
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3634638
@@ -1,3 +1,4 @@
 name,url,icon
 Paper Preprint,https://arxiv.org/abs/2507.20006,paper
-IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_d2d68e75-88a1-4f4a-a1c5-7d8cb6706524.html,other
+IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_d2d68e75-88a1-4f4a-a1c5-7d8cb6706524.html,otherPresentation,https://youtu.be/w72IpVgxklQ,video
+Session Recording,https://youtu.be/w72IpVgxklQ,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3634639
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3634639
@@ -1,2 +1,3 @@
 name,url,icon
-IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_ce206043-1fa9-45b7-801b-2910c1dec585.html,other
+IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_ce206043-1fa9-45b7-801b-2910c1dec585.html,otherPresentation,https://youtu.be/w72IpVgxklQ,video
+Session Recording,https://youtu.be/w72IpVgxklQ,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3634640
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3634640
@@ -1,3 +1,4 @@
 name,url,icon
 Paper Preprint,https://arxiv.org/abs/2507.11848,paper
-IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_4009fec8-7d38-4e00-9e7d-f9493fb32941.html,other
+IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_4009fec8-7d38-4e00-9e7d-f9493fb32941.html,otherPresentation,https://youtu.be/fkfdha6pCeI,video
+Session Recording,https://youtu.be/fkfdha6pCeI,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3634641
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3634641
@@ -3,4 +3,5 @@ Supplemental Material,https://doi.org/10.17605/OSF.IO/79Y5S,other
 Preregistration 1,https://doi.org/10.17605/OSF.IO/RG7FH,other
 Preregistration 2,https://doi.org/10.17605/OSF.IO/GC7QX,other
 Preregistration 3,https://doi.org/10.17605/OSF.IO/F5397,other
-IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_bf10121c-1a25-4391-b766-450e53b2348e.html,other
+IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_bf10121c-1a25-4391-b766-450e53b2348e.html,otherPresentation,https://youtu.be/JQEgOnSg18o,video
+Session Recording,https://youtu.be/JQEgOnSg18o,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3634642
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3634642
@@ -1,2 +1,3 @@
 name,url,icon
-IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_39db4241-5a8e-4bf7-abaf-b638cfbfee08.html,other
+IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_39db4241-5a8e-4bf7-abaf-b638cfbfee08.html,otherPresentation,https://youtu.be/hoMn73KnXCg,video
+Session Recording,https://youtu.be/hoMn73KnXCg,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3634643
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3634643
@@ -1,3 +1,4 @@
 name,url,icon
 Paper Preprint,https://arxiv.org/abs/2507.13586,paper
-IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_77c7ae29-07ac-4a7b-90d1-5ca6794c6632.html,other
+IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_77c7ae29-07ac-4a7b-90d1-5ca6794c6632.html,otherPresentation,https://youtu.be/7jlWgTDmDL8,video
+Session Recording,https://youtu.be/7jlWgTDmDL8,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3634644
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3634644
@@ -2,3 +2,5 @@ name,url,icon
 Paper Preprint,https://arxiv.org/abs/2508.07390,paper
 Website,http://urbantk.org/urbanite,project_website
 IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_f8717d69-b5a1-497d-9241-6b1931d4c195.html,other
+Presentation,https://youtu.be/hoMn73KnXCg,video
+Session Recording,https://youtu.be/hoMn73KnXCg,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3634645
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3634645
@@ -2,3 +2,5 @@ name,url,icon
 Paper Preprint,https://arxiv.org/pdf/2508.01700,paper
 Code,https://github.com/Bvivib-shuai/DeepVIS,code
 IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_f4073f80-c0bd-4d83-9c72-3dcfd060ef7f.html,other
+Presentation,https://youtu.be/JQEgOnSg18o,video
+Session Recording,https://youtu.be/JQEgOnSg18o,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3634646
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3634646
@@ -1,3 +1,4 @@
 name,url,icon
 Paper Preprint,https://arxiv.org/abs/2405.00708,paper
-IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_7a68a26e-4b20-444f-a76a-eee7a08ab3be.html,other
+IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_7a68a26e-4b20-444f-a76a-eee7a08ab3be.html,otherPresentation,https://youtu.be/JQEgOnSg18o,video
+Session Recording,https://youtu.be/JQEgOnSg18o,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3634647
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3634647
@@ -2,3 +2,5 @@ name,url,icon
 Paper Preprint,https://arxiv.org/abs/2508.07496,paper
 Website,http://urbantk.org/streetweave,project_website
 IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_5a5e8c22-ecab-4548-b9f8-3b84454ee079.html,other
+Presentation,https://youtu.be/hoMn73KnXCg,video
+Session Recording,https://youtu.be/hoMn73KnXCg,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3634648
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3634648
@@ -1,2 +1,3 @@
 name,url,icon
-IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_f84ebbf0-98bb-4a65-9640-3161c7449f60.html,other
+IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_f84ebbf0-98bb-4a65-9640-3161c7449f60.html,otherPresentation,https://youtu.be/7jlWgTDmDL8,video
+Session Recording,https://youtu.be/7jlWgTDmDL8,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3634649
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3634649
@@ -3,3 +3,5 @@ Paper Preprint,https://arxiv.org/abs/2507.19690,paper
 Supplemental Material,https://github.com/uwdata/mosaic-selection-benchmarks,other
 Website,https://idl.uw.edu/mosaic,project_website
 IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_603070d4-693a-4aec-8b08-632a59a24c59.html,other
+Presentation,https://youtu.be/wUoqSN_s3tw,video
+Session Recording,https://youtu.be/wUoqSN_s3tw,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3634650
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3634650
@@ -1,3 +1,4 @@
 name,url,icon
 Paper Preprint,https://arxiv.org/abs/2508.06300,paper
-IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_d207baab-2afc-4d7a-bbfd-cf81768ec83c.html,other
+IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_d207baab-2afc-4d7a-bbfd-cf81768ec83c.html,otherPresentation,https://youtu.be/JQEgOnSg18o,video
+Session Recording,https://youtu.be/JQEgOnSg18o,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3634651
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3634651
@@ -1,2 +1,3 @@
 name,url,icon
-IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_3f463b80-5efc-4150-8b6f-3f5fbb1aed72.html,other
+IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_3f463b80-5efc-4150-8b6f-3f5fbb1aed72.html,otherPresentation,https://youtu.be/JQEgOnSg18o,video
+Session Recording,https://youtu.be/JQEgOnSg18o,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3634652
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3634652
@@ -1,3 +1,4 @@
 name,url,icon
 Paper Preprint,http://arxiv.org/abs/2507.13404,paper
-IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_8330bc4e-c9eb-41e0-8fa0-8043f0518241.html,other
+IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_8330bc4e-c9eb-41e0-8fa0-8043f0518241.html,otherPresentation,https://youtu.be/7jlWgTDmDL8,video
+Session Recording,https://youtu.be/7jlWgTDmDL8,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3634653
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3634653
@@ -2,3 +2,5 @@ name,url,icon
 Paper Preprint,https://kclpure.kcl.ac.uk/portal/en/publications/ownershiptracker-a-visual-analytics-approach-to-uncovering-histor,paper
 Website,https://booktracker.nms.kcl.ac.uk/ownership,project_website
 IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_4e91945c-334a-4953-87ed-1564920f05dc.html,other
+Presentation,https://youtu.be/fkfdha6pCeI,video
+Session Recording,https://youtu.be/fkfdha6pCeI,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3634654
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3634654
@@ -3,3 +3,5 @@ Paper Preprint,https://doi.org/10.31219/osf.io/dtr6u_v1,paper
 Live Editor,http://3d.gosling-lang.org,project_website
 3D Genome Survey,https://manzt.github.io/3d-genome-survey/,project_website
 IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_1af413bb-b7e1-4e7a-bbba-ec896ec760e7.html,other
+Presentation,https://youtu.be/7jlWgTDmDL8,video
+Session Recording,https://youtu.be/7jlWgTDmDL8,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3634655
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3634655
@@ -2,3 +2,5 @@ name,url,icon
 Paper Preprint,https://arxiv.org/abs/2507.21124,paper
 Video,https://www.youtube.com/watch?v=P8InRaOBnKI,video
 IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_9e05775a-056c-42f7-a3c2-e81281c5045a.html,other
+Presentation,https://youtu.be/wUoqSN_s3tw,video
+Session Recording,https://youtu.be/wUoqSN_s3tw,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3634656
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3634656
@@ -1,2 +1,3 @@
 name,url,icon
-IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_5f806c3f-27b1-47e9-81ce-9255b7532d0f.html,other
+IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_5f806c3f-27b1-47e9-81ce-9255b7532d0f.html,otherPresentation,https://youtu.be/w72IpVgxklQ,video
+Session Recording,https://youtu.be/w72IpVgxklQ,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3634711
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3634711
@@ -1,3 +1,4 @@
 name,url,icon
 Paper Preprint,https://kclpure.kcl.ac.uk/portal/en/publications/collaborating-across-domains-and-roles-an-interview-study-of-visu,paper
-IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_c7fde6c0-1dc4-4ad4-8413-50cc367ed451.html,other
+IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_c7fde6c0-1dc4-4ad4-8413-50cc367ed451.html,otherPresentation,https://youtu.be/S3LGLxyblpM,video
+Session Recording,https://youtu.be/S3LGLxyblpM,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3634775
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3634775
@@ -2,3 +2,5 @@ name,url,icon
 Paper Preprint,https://osf.io/preprints/osf/p3bva_v1,paper
 Code,https://github.com/SchlossVRL/color_scales_affect,code
 IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_c9fcc45e-0f81-49be-817e-b813e0b61c89.html,other
+Presentation,https://youtu.be/gHCENa3C9X4,video
+Session Recording,https://youtu.be/gHCENa3C9X4,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3634776
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3634776
@@ -2,3 +2,5 @@ name,url,icon
 Paper Preprint,https://arxiv.org/abs/2507.11903,paper
 Website,https://octopusmap.github.io,project_website
 IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_19140b17-2652-4f77-a749-4088ec870052.html,other
+Presentation,https://youtu.be/nkeAR0PgfSw,video
+Session Recording,https://youtu.be/nkeAR0PgfSw,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3634777
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3634777
@@ -2,4 +2,5 @@ name,url,icon
 Paper Preprint,https://arxiv.org/pdf/2508.00233,paper
 Supplemental Material,https://osf.io/8crsp/,other
 Preregistration,https://osf.io/swt4c,other
-IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_ad323fdf-97c1-4e09-a814-a643243d280b.html,other
+IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_ad323fdf-97c1-4e09-a814-a643243d280b.html,otherPresentation,https://youtu.be/j1bJGzUi0jM,video
+Session Recording,https://youtu.be/j1bJGzUi0jM,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3634780
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3634780
@@ -1,2 +1,3 @@
 name,url,icon
-IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_28a70097-2b4f-4ac5-9bb0-7b452093c16b.html,other
+IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_28a70097-2b4f-4ac5-9bb0-7b452093c16b.html,otherPresentation,https://youtu.be/rgq3gdIQGxk,video
+Session Recording,https://youtu.be/rgq3gdIQGxk,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3634781
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3634781
@@ -1,3 +1,5 @@
 name,url,icon
 Code,https://github.com/krisha-mehta/DisclosureInDataVis,code
 IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_184d62a7-fb82-4d6f-9819-6f552e1c6c28.html,other
+Presentation,https://youtu.be/mavB31i3NwM,video
+Session Recording,https://youtu.be/mavB31i3NwM,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3634782
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3634782
@@ -2,3 +2,5 @@ name,url,icon
 Paper Preprint,https://hal.science/view/index/docid/5199752,paper
 Website,https://vis-badges.github.io/#/about,project_website
 IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_49b63c40-81c7-41ec-a38a-9d433769c1c6.html,other
+Presentation,https://youtu.be/253qu_2o0K0,video
+Session Recording,https://youtu.be/253qu_2o0K0,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3634783
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3634783
@@ -2,3 +2,5 @@ name,url,icon
 Paper Preprint,https://arxiv.org/abs/2508.05325,paper
 Website,https://cds-critical-design-strategy.github.io/index.html,project_website
 IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_70fe9706-bf4e-4d28-a8e4-fc5b25dca854.html,other
+Presentation,https://youtu.be/moykjX8QeZI,video
+Session Recording,https://youtu.be/moykjX8QeZI,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3634784
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3634784
@@ -2,3 +2,5 @@ name,url,icon
 Paper Preprint,https://arxiv.org/abs/2507.11984,paper
 Website,https://hyeonword.com/dadr/,project_website
 IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_3d30c2f2-5e29-4f5f-a3bc-05c9fb3e4ea0.html,other
+Presentation,https://youtu.be/lJXNA9vtCPA,video
+Session Recording,https://youtu.be/lJXNA9vtCPA,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3634785
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3634785
@@ -1,3 +1,4 @@
 name,url,icon
 Supplemental Material,https://osf.io/ph4b8/files/osfstorage,other
-IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_de570d65-b80f-4e25-9d54-88f11281e2c5.html,other
+IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_de570d65-b80f-4e25-9d54-88f11281e2c5.html,otherPresentation,https://youtu.be/mavB31i3NwM,video
+Session Recording,https://youtu.be/mavB31i3NwM,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3634786
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3634786
@@ -2,4 +2,5 @@ name,url,icon
 Paper Preprint,https://hal.science/hal-05200516/document,paper
 Supplemental Material,https://osf.io/n4p5c/files/osfstorage,other
 Preregistration,https://osf.io/3djhs,other
-IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_86dbd3cf-0467-4e0e-8612-b70910cdefbc.html,other
+IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_86dbd3cf-0467-4e0e-8612-b70910cdefbc.html,otherPresentation,https://youtu.be/6hTTrGMsPK8,video
+Session Recording,https://youtu.be/6hTTrGMsPK8,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3634788
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3634788
@@ -1,2 +1,3 @@
 name,url,icon
-IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_34e579da-1d6a-4ba7-a6e1-4644a0d2c0b7.html,other
+IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_34e579da-1d6a-4ba7-a6e1-4644a0d2c0b7.html,otherPresentation,https://youtu.be/lJXNA9vtCPA,video
+Session Recording,https://youtu.be/lJXNA9vtCPA,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3634789
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3634789
@@ -1,3 +1,4 @@
 name,url,icon
 Supplemental Material,https://osf.io/w85a4/,other
-IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_a610d354-3cae-4df3-ac69-db5a5a7572a6.html,other
+IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_a610d354-3cae-4df3-ac69-db5a5a7572a6.html,otherPresentation,https://youtu.be/D_j0t7Fy0w0,video
+Session Recording,https://youtu.be/D_j0t7Fy0w0,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3634790
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3634790
@@ -3,3 +3,5 @@ Paper Preprint,https://arxiv.org/abs/2404.01485,paper
 Supplemental Material,https://osf.io/wbrdm/,other
 Website,https://marasolen.github.io/multiscale-vis-ds/,project_website
 IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_09fe1b80-d4a6-454e-bd5f-d49b53eae041.html,other
+Presentation,https://youtu.be/moykjX8QeZI,video
+Session Recording,https://youtu.be/moykjX8QeZI,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3634791
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3634791
@@ -3,3 +3,5 @@ Paper Preprint,https://arxiv.org/abs/2504.05445,paper
 Supplemental Material,https://osf.io/fp3rg/,other
 Website,https://huggingface.co/spaces/uw-insight-lab/Probing-Vis-Literacy-of-VLMs,project_website
 IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_6f935187-a32b-477d-90a0-1a7e959c6222.html,other
+Presentation,https://youtu.be/vzBq3yA2yUs,video
+Session Recording,https://youtu.be/vzBq3yA2yUs,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3634792
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3634792
@@ -2,3 +2,5 @@ name,url,icon
 Paper Preprint,https://osf.io/dfr4p_v2,paper
 Supplemental Material,https://osf.io/xwr4c/,other
 IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_7c5cabc5-b76c-4eba-be3a-c6fcfd508888.html,other
+Presentation,https://youtu.be/R3RWFseiZmo,video
+Session Recording,https://youtu.be/R3RWFseiZmo,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3634794
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3634794
@@ -2,3 +2,5 @@ name,url,icon
 Paper Preprint,https://www.biorxiv.org/content/10.1101/2025.07.19.665696,paper
 Website,https://sealvis.com/,project_website
 IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_3eefd0dc-4542-4d3b-8a9e-bd1530cdebab.html,other
+Presentation,https://youtu.be/lJXNA9vtCPA,video
+Session Recording,https://youtu.be/lJXNA9vtCPA,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3634795
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3634795
@@ -1,4 +1,5 @@
 name,url,icon
 Paper Preprint,https://hal.science/hal-05171203,paper
 Supplemental Material,https://osf.io/ hybvp/?view_only=5cd17943e9ba46deb66a8f7f4eeeb4da,other
-IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_80f2d2e8-877c-469a-8ce2-bb3e5bea1f93.html,other
+IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_80f2d2e8-877c-469a-8ce2-bb3e5bea1f93.html,otherPresentation,https://youtu.be/D_j0t7Fy0w0,video
+Session Recording,https://youtu.be/D_j0t7Fy0w0,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3634798
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3634798
@@ -1,3 +1,5 @@
 name,url,icon
 Supplemental Material,https://osf.io/sv4fn/,other
 IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_33454738-a9a9-4944-a27f-262d1da9f35d.html,other
+Presentation,https://youtu.be/6hTTrGMsPK8,video
+Session Recording,https://youtu.be/6hTTrGMsPK8,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3634803
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3634803
@@ -1,3 +1,4 @@
 name,url,icon
 Paper Preprint,https://arxiv.org/pdf/2507.12298,paper
-IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_3f0a5ad9-2440-47b4-a741-f6b92c58bf8d.html,other
+IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_3f0a5ad9-2440-47b4-a741-f6b92c58bf8d.html,otherPresentation,https://youtu.be/rgq3gdIQGxk,video
+Session Recording,https://youtu.be/rgq3gdIQGxk,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3634806
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3634806
@@ -1,3 +1,5 @@
 name,url,icon
 Code,https://github.com/Happy-Hippo209/ConceptViz,code
 IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_1f23efb5-deca-4391-a7c4-e455fce74cb9.html,other
+Presentation,https://youtu.be/LajPfGQe32k,video
+Session Recording,https://youtu.be/LajPfGQe32k,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3634807
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3634807
@@ -1,3 +1,4 @@
 name,url,icon
 Supplemental Material,https://osf.io/y3z2b/?view_only=7f6569187b344fadbd11cc09a6e63d24,other
-IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_8aa31c36-374d-4155-b9c3-fd20d8deeec2.html,other
+IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_8aa31c36-374d-4155-b9c3-fd20d8deeec2.html,otherPresentation,https://youtu.be/D_j0t7Fy0w0,video
+Session Recording,https://youtu.be/D_j0t7Fy0w0,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3634808
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3634808
@@ -2,3 +2,5 @@ name,url,icon
 Paper Preprint,https://www.biorxiv.org/content/10.1101/2025.07.02.662847v1,paper
 Code,https://github.com/VCG/momo,codd
 IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_bba75087-a544-4e3c-85f9-947b8b3537dc.html,other
+Presentation,https://youtu.be/vzBq3yA2yUs,video
+Session Recording,https://youtu.be/vzBq3yA2yUs,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3634809
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3634809
@@ -3,3 +3,5 @@ Paper Preprint,https://arxiv.org/abs/2508.07497,paper
 Website,http://urbantk.org/va-blueprint,project_website
 Website,https://leovsferreira.github.io/va-building-blocks/,project_website
 IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_f2b6c739-7eed-4161-a955-230c614bae12.html,other
+Presentation,https://youtu.be/vzBq3yA2yUs,video
+Session Recording,https://youtu.be/vzBq3yA2yUs,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3634811
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3634811
@@ -1,4 +1,5 @@
 name,url,icon
 Paper Preprint,https://arxiv.org/abs/2508.02216,paper
 Supplemental Material,https://osf.io/fqpdh/,other
-IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_cf7e7577-abbd-426a-bf21-3f2fbffe5aad.html,other
+IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_cf7e7577-abbd-426a-bf21-3f2fbffe5aad.html,otherPresentation,https://youtu.be/S3LGLxyblpM,video
+Session Recording,https://youtu.be/S3LGLxyblpM,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3634812
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3634812
@@ -1,3 +1,4 @@
 name,url,icon
 Paper Preprint,https://arxiv.org/abs/2507.03836,paper
-IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_72737da9-0932-41f6-99a2-803817cf8c15.html,other
+IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_72737da9-0932-41f6-99a2-803817cf8c15.html,otherPresentation,https://youtu.be/-M293vb-AIg,video
+Session Recording,https://youtu.be/-M293vb-AIg,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3634813
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3634813
@@ -2,3 +2,5 @@ name,url,icon
 Paper Preprint,https://arxiv.org/abs/2508.04842,paper
 Code,https://github.com/vhcailab/Charts-of-Thought,code
 IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_fcafb37e-70f2-4d68-b9a4-e92902d9d2bd.html,other
+Presentation,https://youtu.be/R3RWFseiZmo,video
+Session Recording,https://youtu.be/R3RWFseiZmo,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3634814
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3634814
@@ -1,3 +1,4 @@
 name,url,icon
 Supplemental Material,https://doi.org/10.17605/OSF.IO/ERC6P,other
-IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_6a8c1148-d065-4251-9183-2955b9445817.html,other
+IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_6a8c1148-d065-4251-9183-2955b9445817.html,otherPresentation,https://youtu.be/mavB31i3NwM,video
+Session Recording,https://youtu.be/mavB31i3NwM,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3634815
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3634815
@@ -3,3 +3,5 @@ Paper Preprint,https://arxiv.org/abs/2508.03713,paper
 Supplemental Material,https://osf.io/2crb9/,other
 Website,https://minsukchang.info/Lit-Att/,project_website
 IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_22ccb527-7a1d-49e1-81b8-9e4f335089e1.html,other
+Presentation,https://youtu.be/R3RWFseiZmo,video
+Session Recording,https://youtu.be/R3RWFseiZmo,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3634816
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3634816
@@ -2,3 +2,5 @@ name,url,icon
 Paper Preprint,https://arxiv.org/abs/2507.16466,paper
 Website,https://lynnegao.me/scene-loom/,project_website
 IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_2b7f7862-26fb-4ce7-81a9-01537d804ead.html,other
+Presentation,https://youtu.be/j1bJGzUi0jM,video
+Session Recording,https://youtu.be/j1bJGzUi0jM,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3634817
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3634817
@@ -1,4 +1,5 @@
 name,url,icon
 Paper Preprint,https://phaidra.fhstp.ac.at/detail/o:7302,paper
 Supplemental Material,https://phaidra.fhstp.ac.at/detail/o:7304,other
-IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_851f1b42-91da-4dcc-a08e-c6d8e564d251.html,other
+IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_851f1b42-91da-4dcc-a08e-c6d8e564d251.html,otherPresentation,https://youtu.be/R3RWFseiZmo,video
+Session Recording,https://youtu.be/R3RWFseiZmo,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3634818
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3634818
@@ -1,3 +1,4 @@
 name,url,icon
 Paper Preprint,https://arxiv.org/pdf/2507.14459,paper
-IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_88a99aaa-b89c-494c-b810-2113f43914ab.html,other
+IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_88a99aaa-b89c-494c-b810-2113f43914ab.html,otherPresentation,https://youtu.be/M8ysk79s5d8,video
+Session Recording,https://youtu.be/M8ysk79s5d8,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3634819
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3634819
@@ -1,3 +1,4 @@
 name,url,icon
 Supplemental Material,https://doi.org/10.17605/OSF.IO/23HYX,other
-IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_c35d8073-d3b1-4978-bdd4-0b428299f354.html,other
+IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_c35d8073-d3b1-4978-bdd4-0b428299f354.html,otherPresentation,https://youtu.be/mavB31i3NwM,video
+Session Recording,https://youtu.be/mavB31i3NwM,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3634820
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3634820
@@ -1,3 +1,4 @@
 name,url,icon
 Paper Preprint,https://arxiv.org/abs/2507.10024,paper
-IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_29656e00-00d7-4080-b589-2d7c838c72be.html,other
+IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_29656e00-00d7-4080-b589-2d7c838c72be.html,otherPresentation,https://youtu.be/zLchh59XyM4,video
+Session Recording,https://youtu.be/zLchh59XyM4,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3634821
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3634821
@@ -1,4 +1,5 @@
 name,url,icon
 Paper Preprint,https://osf.io/preprints/osf/dn32z_v2,paper
 Supplemental Material,https://osf.io/f89jp/,other
-IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_849ca631-398a-4087-9f66-a0837fc3af86.html,other
+IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_849ca631-398a-4087-9f66-a0837fc3af86.html,otherPresentation,https://youtu.be/vzBq3yA2yUs,video
+Session Recording,https://youtu.be/vzBq3yA2yUs,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3634823
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3634823
@@ -1,3 +1,5 @@
 name,url,icon
 Code,https://github.com/aaschr/vis_2025_smoke_surfaces_for_AD,code
 IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_7b762da7-ec92-461b-ab0a-95e7e278234d.html,other
+Presentation,https://youtu.be/rgq3gdIQGxk,video
+Session Recording,https://youtu.be/rgq3gdIQGxk,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3634824
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3634824
@@ -3,3 +3,5 @@ Code,https://github.com/PytorchConnectomics/SynAnno,code
 Demo 1,http://54.210.88.222/demo,project_website
 Demo 2,http://54.210.88.222/reset,project_website
 IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_b5d2c402-def7-4b9d-a6df-ac4ad7572111.html,other
+Presentation,https://youtu.be/1kLUiSSxIuM,video
+Session Recording,https://youtu.be/1kLUiSSxIuM,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3634830
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3634830
@@ -1,4 +1,5 @@
 name,url,icon
 Paper Preprint,https://arxiv.org/abs/2507.12377,paper
 Supplemental Material,https://osf.io/5fr48/,other
-IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_9d0c979c-02fc-47d5-9f8f-50fc27cf9c35.html,other
+IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_9d0c979c-02fc-47d5-9f8f-50fc27cf9c35.html,otherPresentation,https://youtu.be/j1bJGzUi0jM,video
+Session Recording,https://youtu.be/j1bJGzUi0jM,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3634833
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3634833
@@ -1,2 +1,3 @@
 name,url,icon
-IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_3ca02fd1-d387-44fa-b576-413ea269d949.html,other
+IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_3ca02fd1-d387-44fa-b576-413ea269d949.html,otherPresentation,https://youtu.be/rgq3gdIQGxk,video
+Session Recording,https://youtu.be/rgq3gdIQGxk,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3634837
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3634837
@@ -1,4 +1,5 @@
 name,url,icon
 Paper Preprint,https://doi.org/10.31219/osf.io/n5dxe_v1,paper
 Supplemental Material,https://osf.io/6az29/,other
-IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_440d12ea-914c-49b0-a380-163dab6a3e41.html,other
+IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_440d12ea-914c-49b0-a380-163dab6a3e41.html,otherPresentation,https://youtu.be/253qu_2o0K0,video
+Session Recording,https://youtu.be/253qu_2o0K0,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3634843
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3634843
@@ -3,3 +3,5 @@ Paper Preprint,https://arxiv.org/abs/2507.16117,paper
 Code,https://github.com/VIDA-NYU/bdi-viz,code
 Website,https://bdiviz.users.hsrn.nyu.edu/dashboard/,project_webste
 IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_e8f720e9-fa87-43c1-9d57-b8cc150f3cd3.html,other
+Presentation,https://youtu.be/rgq3gdIQGxk,video
+Session Recording,https://youtu.be/rgq3gdIQGxk,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3634844
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3634844
@@ -1,2 +1,3 @@
 name,url,icon
-IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_84ab0ade-9529-4942-b5e1-ca953e56c880.html,other
+IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_84ab0ade-9529-4942-b5e1-ca953e56c880.html,otherPresentation,https://youtu.be/ar3ziIYBxhc,video
+Session Recording,https://youtu.be/ar3ziIYBxhc,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3634845
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3634845
@@ -1,2 +1,3 @@
 name,url,icon
-IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_b71e9ec2-8579-410a-94c0-a9e2812a2712.html,other
+IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_b71e9ec2-8579-410a-94c0-a9e2812a2712.html,otherPresentation,https://youtu.be/ar3ziIYBxhc,video
+Session Recording,https://youtu.be/ar3ziIYBxhc,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3634875
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3634875
@@ -1,4 +1,5 @@
 name,url,icon
 Paper Preprint,http://arxiv.org/abs/2507.15620,paper
 Supplemental Material,https://doi.org/10.17605/OSF.IO/ETFJ2,other
-IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_9d6c7874-e4fa-449b-88aa-4b3937241e7d.html,other
+IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_9d6c7874-e4fa-449b-88aa-4b3937241e7d.html,otherPresentation,https://youtu.be/rgq3gdIQGxk,video
+Session Recording,https://youtu.be/rgq3gdIQGxk,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3634876
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3634876
@@ -1,3 +1,4 @@
 name,url,icon
 Paper Preprint,https://kclpure.kcl.ac.uk/portal/en/publications/set-size-matters-capacity-limited-perception-of-grouped-spatial-f,paper
-IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_1acd711b-69a4-486f-9955-0f6adb58292b.html,other
+IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_1acd711b-69a4-486f-9955-0f6adb58292b.html,otherPresentation,https://youtu.be/gHCENa3C9X4,video
+Session Recording,https://youtu.be/gHCENa3C9X4,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3642506
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3642506
@@ -2,3 +2,5 @@ name,url,icon
 Paper Preprint,https://vccvisualization.org/research/observerspaces/,paper
 Code,https://github.com/Cindy-xdZhang/PyflowVis,code
 IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_fb22d5c6-8a2f-4d98-80ec-1fbbfed18538.html,other
+Presentation,https://youtu.be/ar3ziIYBxhc,video
+Session Recording,https://youtu.be/ar3ziIYBxhc,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3642509
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3642509
@@ -1,2 +1,3 @@
 name,url,icon
-IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_9e9a15b7-6ccb-4419-b391-e82e3bd8b907.html,other
+IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_9e9a15b7-6ccb-4419-b391-e82e3bd8b907.html,otherPresentation,https://youtu.be/j1bJGzUi0jM,video
+Session Recording,https://youtu.be/j1bJGzUi0jM,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3642516
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3642516
@@ -1,3 +1,4 @@
 name,url,icon
 Paper Preprint,https://arxiv.org/abs/2507.12667,paper
-IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_3d97e8c0-6d8b-4fe5-aa06-3ddf284b1a45.html,other
+IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_3d97e8c0-6d8b-4fe5-aa06-3ddf284b1a45.html,otherPresentation,https://youtu.be/-M293vb-AIg,video
+Session Recording,https://youtu.be/-M293vb-AIg,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3642518
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3642518
@@ -1,3 +1,5 @@
 name,url,icon
 Website,https://jingweiqu.github.io/project/LPCE,project_website
 IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_4becbe1b-2bde-4b12-adfd-e45a36678884.html,other
+Presentation,https://youtu.be/1kLUiSSxIuM,video
+Session Recording,https://youtu.be/1kLUiSSxIuM,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3642628
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3642628
@@ -1,3 +1,4 @@
 name,url,icon
 Paper Preprint,https://www.arxiv.org/abs/2507.18165,paper
-IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_47c46990-8edb-4014-be27-c1c07f128d60.html,other
+IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_47c46990-8edb-4014-be27-c1c07f128d60.html,otherPresentation,https://youtu.be/2z0_8lHbM04,video
+Session Recording,https://youtu.be/2z0_8lHbM04,video

--- a/public/data/paperLinks/10.1109/TVCG.2025.3642641
+++ b/public/data/paperLinks/10.1109/TVCG.2025.3642641
@@ -1,3 +1,5 @@
 name,url,icon
 Code,https://github.com/HKUST-CIVAL/DKMap,code
 IEEE VIS Conference Page,https://ieeevis.org/year/2025/program/paper_3d649242-7596-4300-84fe-793b6a69b69c.html,other
+Presentation,https://youtu.be/1kLUiSSxIuM,video
+Session Recording,https://youtu.be/1kLUiSSxIuM,video

--- a/src/dataProcess/ingest_vis_videos.py
+++ b/src/dataProcess/ingest_vis_videos.py
@@ -1,0 +1,175 @@
+"""Ingest video links from IEEE VIS program data into paperLinks files.
+
+Fetches the program papers.json from the ieee-vgtc/ieeevis.org GitHub repo
+for a given year and adds video links (presentation, fast-forward, session
+recordings) to the corresponding paperLinks CSV files.
+
+Matching is done by paper title (case-insensitive) against papers.csv, since
+DOIs in the program JSON often differ from the final published DOIs in
+papers.csv.
+
+Usage:
+    python ingest_vis_videos.py --year 2024
+    python ingest_vis_videos.py --year 2025
+
+Source data:
+    https://raw.githubusercontent.com/ieee-vgtc/ieeevis.org/vis{year}/program/papers.json
+
+Video fields by year:
+    2024: prerecorded_video_link, youtube_ff_url, session_bunny_ff_link
+    2025: youtube_url, youtube_ff_url, session_youtube_url, session_bunny_ff_link
+"""
+
+import argparse
+import csv
+import json
+import os
+import re
+import urllib.request
+
+REPO_ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
+PAPERS_CSV = os.path.join(REPO_ROOT, "public", "data", "papers.csv")
+PAPER_LINKS_DIR = os.path.join(REPO_ROOT, "public", "data", "paperLinks")
+SOURCE_URL = "https://raw.githubusercontent.com/ieee-vgtc/ieeevis.org/vis{year}/program/papers.json"
+
+
+def build_title_to_doi_map():
+    """Build a case-insensitive title -> DOI lookup from papers.csv."""
+    title_map = {}
+    with open(PAPERS_CSV, newline="", encoding="utf-8") as f:
+        for row in csv.DictReader(f):
+            title = (row.get("Title") or "").strip().lower()
+            doi = (row.get("DOI") or "").strip()
+            if title and doi:
+                title_map[title] = doi
+    return title_map
+
+
+def normalize_youtube_url(url):
+    """Convert embed/nocookie YouTube URLs to standard youtu.be format."""
+    if not url:
+        return url
+    match = re.match(r"https?://(?:www\.)?youtube(?:-nocookie)?\.com/embed/([^?&/]+)", url)
+    if match:
+        video_id = match.group(1)
+        return f"https://youtu.be/{video_id}"
+    return url
+
+
+def read_existing_urls(filepath):
+    """Read existing URLs from a paperLinks CSV file."""
+    if not os.path.isfile(filepath):
+        return set()
+    urls = set()
+    with open(filepath, newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            url = (row.get("url") or "").strip()
+            if url:
+                urls.add(url)
+    return urls
+
+
+def append_links(filepath, links):
+    """Append new video links to a paperLinks CSV file."""
+    if not os.path.isfile(filepath):
+        os.makedirs(os.path.dirname(filepath), exist_ok=True)
+        with open(filepath, "w", newline="", encoding="utf-8") as f:
+            f.write("name,url,icon\n")
+
+    with open(filepath, "a", newline="", encoding="utf-8") as f:
+        writer = csv.writer(f)
+        for name, url, icon in links:
+            writer.writerow([name, url, icon])
+
+
+def extract_video_links(entry):
+    """Extract video links from a program JSON entry."""
+    links = []
+
+    # Presentation video
+    for field in ["youtube_url", "prerecorded_video_link"]:
+        url = (entry.get(field) or "").strip()
+        if url:
+            links.append(("Presentation", normalize_youtube_url(url), "video"))
+            break
+
+    # Fast-forward video
+    url = (entry.get("youtube_ff_url") or "").strip()
+    if url:
+        links.append(("Fast Forward", normalize_youtube_url(url), "video"))
+
+    # Session recording
+    for field in ["session_youtube_url", "session_bunny_ff_link"]:
+        url = (entry.get(field) or "").strip()
+        if url:
+            links.append(("Session Recording", normalize_youtube_url(url), "video"))
+            break
+
+    return links
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Ingest VIS video links into paperLinks")
+    parser.add_argument("--year", required=True, type=int, help="VIS conference year (e.g., 2024)")
+    args = parser.parse_args()
+
+    url = SOURCE_URL.format(year=args.year)
+    print(f"Fetching {url}...")
+
+    with urllib.request.urlopen(url) as response:
+        data = json.loads(response.read().decode("utf-8"))
+
+    print(f"Found {len(data)} entries in program JSON")
+    print("Building title lookup from papers.csv...")
+    title_to_doi = build_title_to_doi_map()
+
+    stats = {
+        "matched": 0,
+        "videos_added": 0,
+        "skipped_no_video": 0,
+        "skipped_no_match": 0,
+        "skipped_duplicate": 0,
+    }
+
+    for entry in data:
+        title = (entry.get("title") or "").strip().lower()
+        if not title:
+            stats["skipped_no_match"] += 1
+            continue
+
+        doi = title_to_doi.get(title)
+        if not doi:
+            stats["skipped_no_match"] += 1
+            continue
+
+        video_links = extract_video_links(entry)
+        if not video_links:
+            stats["matched"] += 1
+            stats["skipped_no_video"] += 1
+            continue
+
+        stats["matched"] += 1
+        filepath = os.path.join(PAPER_LINKS_DIR, doi)
+        existing_urls = read_existing_urls(filepath)
+        new_links = []
+        for name, link_url, icon in video_links:
+            if link_url not in existing_urls:
+                new_links.append((name, link_url, icon))
+            else:
+                stats["skipped_duplicate"] += 1
+
+        if new_links:
+            append_links(filepath, new_links)
+            stats["videos_added"] += len(new_links)
+
+    print(f"\n--- Summary for VIS {args.year} ---")
+    print(f"Papers matched by title: {stats['matched']}")
+    print(f"Videos added: {stats['videos_added']}")
+    print(f"Skipped (no title match in papers.csv): {stats['skipped_no_match']}")
+    print(f"Skipped (matched but no video URLs): {stats['skipped_no_video']}")
+    print(f"Skipped (duplicate URL already in file): {stats['skipped_duplicate']}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add `src/dataProcess/ingest_vis_videos.py` — reusable script to fetch video links from IEEE VIS program JSON
- Ingested videos for VIS 2024 (212 links) and VIS 2025 (238 links) — 450 total new video entries
- Matches papers by title (case-insensitive) since program JSON DOIs differ from published DOIs
- Updated Resources flags via `update_paper_link_flags.py`

## Changes
- **`src/dataProcess/ingest_vis_videos.py`** — New script with `--year` CLI arg
- **`public/data/paperLinks/`** — 226 files updated with video links
- **`public/data/papers.csv`** — Resources column updated

## Spec
`.claude/todo/add-vis-video-sources.md`

## Test plan
- [ ] Run `python src/dataProcess/ingest_vis_videos.py --year 2025` (should show 0 new videos — already ingested)
- [ ] Spot-check a paperLinks file: `cat public/data/paperLinks/10.1109/TVCG.2025.3633874` (should have Presentation video)
- [ ] Verify the script handles re-runs gracefully (deduplicates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)