### PR TITLE
Add sandboxed plugin framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ For the specific Licenses I use two different licenses. One for the data files, 
 - Data Files (everything in public/data): CC-By 4.0, International. See LICENSE-DATA.md.
 - Other Code (everything else): Apache 2.0. See LICENSE.
 
+## Plugins
+
+VisPubs supports third-party plugins that render alongside the paper list in a sandboxed iframe. Load one via `?plugin=<url>`; see [docs/plugins.md](docs/plugins.md) for the message protocol, security model, and the reference example plugin.
+
 # For Developer
 
 ## Install the dependencies

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,0 +1,96 @@
+# VisPubs plugin framework
+
+VisPubs supports third-party plugins that render alongside the paper list. A plugin is just a URL that serves HTML/JS — a GitHub gist raw URL, a CodePen export, a self-hosted page, or a file in this repo's `public/plugins/` folder.
+
+Plugins are activated per-session via a query parameter, so any plugin link is shareable.
+
+## Loading a plugin
+
+```
+https://vispubs.com/?plugin=<url>
+https://vispubs.com/?plugin=<url>&pluginOrientation=vertical
+```
+
+- `plugin` — the plugin URL. Relative URLs resolve against vispubs's origin.
+- `pluginOrientation` — `horizontal` (default, side-by-side) or `vertical` (stacked).
+
+On first load of a new plugin URL, vispubs shows a confirmation dialog naming the origin. Approval is session-scoped: reloading the tab re-prompts, and sharing a link always re-prompts in the recipient's session.
+
+Reference plugin: [`/plugins/example-scatterplot.html`](../public/plugins/example-scatterplot.html).
+
+```
+https://vispubs.com/?plugin=/plugins/example-scatterplot.html
+```
+
+## Security model
+
+Plugins load inside `<iframe sandbox="allow-scripts">`. No `allow-same-origin`, no forms, no storage, no popups. This means a plugin:
+
+- Cannot read cookies, localStorage, sessionStorage, or IndexedDB on vispubs.com.
+- Cannot touch the parent DOM or any other origin's data.
+- Cannot navigate the top window or open popups.
+- Receives data only through `postMessage` from the host.
+
+All data the host sends (from `papers.csv`) is already public, so the sandbox is defense-in-depth: it protects users against a malicious shared `?plugin=...` link, not against exposure of sensitive data.
+
+## Message protocol
+
+All messages use a `vispubs:` type prefix. Anything without that prefix is ignored. Plugins should send messages to `window.parent` with target origin `'*'`.
+
+### Host → plugin
+
+The host sends `vispubs:state` in response to `vispubs:ready`, then again on every relevant reactive change (debounced ~150 ms).
+
+```ts
+{
+  type: 'vispubs:state',
+  papers: PluginPaper[],         // current filtered list, in display order
+  filters: PluginFilterState,    // search, year, venue, award, resource, collection
+  selectedDoi: string | null,    // paper open in the detail drawer
+  focusedDoi: string | null,     // paper highlighted (keyboard/hover focus)
+  darkMode: boolean,
+}
+```
+
+See [`src/types/plugin.ts`](../src/types/plugin.ts) for the full shape, including `PluginPaper` and `PluginFilterState`.
+
+### Plugin → host
+
+| Message | Effect |
+| --- | --- |
+| `{ type: 'vispubs:ready' }` | Tells the host the plugin is wired and requests the initial state. Send this once after your message listener is attached. |
+| `{ type: 'vispubs:selectPaper', doi }` | Opens the paper with the given DOI in the right-side detail drawer. |
+| `{ type: 'vispubs:focusPaper', doi }` | Highlights the paper in the list. Pass `doi: null` to clear focus. |
+
+The host validates every incoming message:
+
+- `event.source` must match the plugin's iframe window. Messages from other frames are ignored.
+- Messages whose `type` is missing or doesn't start with `vispubs:` are dropped.
+- `selectPaper`/`focusPaper` are no-ops if the DOI is not in the current filtered list.
+
+## Minimal plugin template
+
+```html
+<!doctype html>
+<html>
+  <body>
+    <pre id="out"></pre>
+    <script>
+      window.addEventListener('message', (event) => {
+        if (!event.data || event.data.type !== 'vispubs:state') return;
+        document.getElementById('out').textContent =
+          event.data.papers.length + ' papers';
+      });
+      window.parent.postMessage({ type: 'vispubs:ready' }, '*');
+    </script>
+  </body>
+</html>
+```
+
+## Out of scope
+
+- Multiple plugins at once.
+- In-repo Vue-component plugins (same protocol, no iframe) — may land later.
+- Plugin contributions to FilterPanel, PaperInformation, or new top-level routes.
+- A persistent plugin registry or curated plugin picker in the UI.
+- Plugin-provided filter dimensions that feed back into the host's paper set.

--- a/public/plugins/example-scatterplot.html
+++ b/public/plugins/example-scatterplot.html
@@ -1,0 +1,312 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>vispubs example scatterplot</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        height: 100%;
+        width: 100%;
+        overflow: hidden;
+        font-family:
+          -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      }
+      body {
+        display: flex;
+        flex-direction: column;
+      }
+      #info {
+        flex: 0 0 auto;
+        padding: 6px 10px;
+        font-size: 12px;
+        border-bottom: 1px solid rgba(128, 128, 128, 0.3);
+      }
+      #info .muted {
+        opacity: 0.7;
+      }
+      #canvas-wrap {
+        flex: 1 1 auto;
+        position: relative;
+        min-height: 0;
+      }
+      canvas {
+        position: absolute;
+        inset: 0;
+        width: 100%;
+        height: 100%;
+        display: block;
+      }
+      body.dark {
+        background: #1d1d1d;
+        color: #eee;
+      }
+      body.light {
+        background: #fafafa;
+        color: #222;
+      }
+    </style>
+  </head>
+  <body class="light">
+    <div id="info">
+      <span id="count" class="muted">Waiting for vispubs…</span>
+    </div>
+    <div id="canvas-wrap">
+      <canvas id="chart"></canvas>
+    </div>
+
+    <script>
+      (function () {
+        'use strict';
+
+        const canvas = document.getElementById('chart');
+        const ctx = canvas.getContext('2d');
+        const info = document.getElementById('count');
+
+        let state = null;
+        let layout = null;
+        let hoveredDoi = null;
+        let dpr = window.devicePixelRatio || 1;
+
+        function resizeCanvas() {
+          const wrap = canvas.parentElement;
+          const w = wrap.clientWidth;
+          const h = wrap.clientHeight;
+          canvas.width = Math.max(1, Math.floor(w * dpr));
+          canvas.height = Math.max(1, Math.floor(h * dpr));
+          canvas.style.width = w + 'px';
+          canvas.style.height = h + 'px';
+          computeLayout();
+          draw();
+        }
+
+        function computeLayout() {
+          if (!state || !state.papers || state.papers.length === 0) {
+            layout = null;
+            return;
+          }
+          const papers = state.papers;
+
+          const byYear = new Map();
+          for (const p of papers) {
+            const year = p.year;
+            if (!byYear.has(year)) byYear.set(year, []);
+            byYear.get(year).push(p);
+          }
+          let minYear = Infinity;
+          let maxYear = -Infinity;
+          let maxCount = 0;
+          for (const [year, list] of byYear) {
+            if (year < minYear) minYear = year;
+            if (year > maxYear) maxYear = year;
+            if (list.length > maxCount) maxCount = list.length;
+          }
+          if (minYear === maxYear) {
+            minYear -= 0.5;
+            maxYear += 0.5;
+          }
+
+          const W = canvas.width;
+          const H = canvas.height;
+          const padL = 44 * dpr;
+          const padR = 12 * dpr;
+          const padT = 12 * dpr;
+          const padB = 28 * dpr;
+          const plotW = Math.max(1, W - padL - padR);
+          const plotH = Math.max(1, H - padT - padB);
+
+          const yearSpan = maxYear - minYear || 1;
+          const radius = Math.max(2 * dpr, Math.min(6 * dpr, plotW / papers.length));
+
+          const points = [];
+          const indexByDoi = new Map();
+          const yearCursor = new Map();
+          for (const p of papers) {
+            const cursor = (yearCursor.get(p.year) || 0);
+            yearCursor.set(p.year, cursor + 1);
+            const x = padL + ((p.year - minYear) / yearSpan) * plotW;
+            const yFrac = maxCount > 1 ? cursor / (maxCount - 1) : 0.5;
+            const y = padT + plotH - yFrac * plotH;
+            indexByDoi.set(p.doi, points.length);
+            points.push({ doi: p.doi, x, y, year: p.year });
+          }
+
+          layout = {
+            points,
+            indexByDoi,
+            minYear,
+            maxYear,
+            maxCount,
+            padL,
+            padR,
+            padT,
+            padB,
+            plotW,
+            plotH,
+            radius,
+          };
+        }
+
+        function colorForPaper(p, isSelected, isFocused) {
+          const darkMode = state && state.darkMode;
+          if (isSelected) return darkMode ? '#ffd54f' : '#f57c00';
+          if (isFocused) return darkMode ? '#80cbc4' : '#00796b';
+          return darkMode ? '#90a4ae' : '#546e7a';
+        }
+
+        function draw() {
+          const W = canvas.width;
+          const H = canvas.height;
+          ctx.clearRect(0, 0, W, H);
+          if (!state || !layout) return;
+
+          const darkMode = state.darkMode;
+          ctx.strokeStyle = darkMode
+            ? 'rgba(255,255,255,0.4)'
+            : 'rgba(0,0,0,0.4)';
+          ctx.fillStyle = darkMode ? '#eee' : '#222';
+          ctx.lineWidth = 1 * dpr;
+          ctx.font = `${11 * dpr}px sans-serif`;
+          ctx.textBaseline = 'middle';
+
+          ctx.beginPath();
+          ctx.moveTo(layout.padL, layout.padT);
+          ctx.lineTo(layout.padL, layout.padT + layout.plotH);
+          ctx.lineTo(layout.padL + layout.plotW, layout.padT + layout.plotH);
+          ctx.stroke();
+
+          ctx.textAlign = 'right';
+          ctx.fillText(
+            String(layout.maxCount),
+            layout.padL - 4 * dpr,
+            layout.padT + 4 * dpr
+          );
+          ctx.fillText(
+            '0',
+            layout.padL - 4 * dpr,
+            layout.padT + layout.plotH - 2 * dpr
+          );
+
+          ctx.textAlign = 'center';
+          const ty = layout.padT + layout.plotH + 16 * dpr;
+          const yearTicks = Math.max(2, Math.min(8, Math.round(layout.plotW / (60 * dpr))));
+          for (let i = 0; i <= yearTicks; i++) {
+            const year = Math.round(
+              layout.minYear + (i / yearTicks) * (layout.maxYear - layout.minYear)
+            );
+            const x =
+              layout.padL + ((year - layout.minYear) / (layout.maxYear - layout.minYear || 1)) * layout.plotW;
+            ctx.fillText(String(year), x, ty);
+          }
+
+          const selectedIdx = state.selectedDoi
+            ? layout.indexByDoi.get(state.selectedDoi)
+            : null;
+          const focusedIdx = state.focusedDoi
+            ? layout.indexByDoi.get(state.focusedDoi)
+            : null;
+
+          for (let i = 0; i < layout.points.length; i++) {
+            if (i === selectedIdx || i === focusedIdx) continue;
+            const pt = layout.points[i];
+            ctx.fillStyle = colorForPaper(pt, false, false);
+            ctx.beginPath();
+            ctx.arc(pt.x, pt.y, layout.radius, 0, Math.PI * 2);
+            ctx.fill();
+          }
+
+          if (focusedIdx != null) {
+            const pt = layout.points[focusedIdx];
+            ctx.fillStyle = colorForPaper(pt, false, true);
+            ctx.beginPath();
+            ctx.arc(pt.x, pt.y, layout.radius * 1.6, 0, Math.PI * 2);
+            ctx.fill();
+          }
+          if (selectedIdx != null) {
+            const pt = layout.points[selectedIdx];
+            ctx.fillStyle = colorForPaper(pt, true, false);
+            ctx.strokeStyle = darkMode ? '#fff' : '#000';
+            ctx.lineWidth = 2 * dpr;
+            ctx.beginPath();
+            ctx.arc(pt.x, pt.y, layout.radius * 2, 0, Math.PI * 2);
+            ctx.fill();
+            ctx.stroke();
+          }
+        }
+
+        function hitTest(clientX, clientY) {
+          if (!layout) return null;
+          const rect = canvas.getBoundingClientRect();
+          const x = (clientX - rect.left) * dpr;
+          const y = (clientY - rect.top) * dpr;
+          const r = layout.radius * 2.2;
+          const r2 = r * r;
+          let best = null;
+          let bestDist = r2;
+          for (const pt of layout.points) {
+            const dx = pt.x - x;
+            const dy = pt.y - y;
+            const d = dx * dx + dy * dy;
+            if (d <= bestDist) {
+              bestDist = d;
+              best = pt;
+            }
+          }
+          return best;
+        }
+
+        canvas.addEventListener('pointermove', function (event) {
+          const hit = hitTest(event.clientX, event.clientY);
+          const doi = hit ? hit.doi : null;
+          if (doi === hoveredDoi) return;
+          hoveredDoi = doi;
+          window.parent.postMessage(
+            { type: 'vispubs:focusPaper', doi: doi },
+            '*'
+          );
+        });
+
+        canvas.addEventListener('pointerleave', function () {
+          if (hoveredDoi == null) return;
+          hoveredDoi = null;
+          window.parent.postMessage(
+            { type: 'vispubs:focusPaper', doi: null },
+            '*'
+          );
+        });
+
+        canvas.addEventListener('click', function (event) {
+          const hit = hitTest(event.clientX, event.clientY);
+          if (!hit) return;
+          window.parent.postMessage(
+            { type: 'vispubs:selectPaper', doi: hit.doi },
+            '*'
+          );
+        });
+
+        window.addEventListener('message', function (event) {
+          const data = event.data;
+          if (!data || data.type !== 'vispubs:state') return;
+          state = data;
+          document.body.className = state.darkMode ? 'dark' : 'light';
+          info.textContent =
+            state.papers.length +
+            ' paper' +
+            (state.papers.length === 1 ? '' : 's') +
+            (state.filters && state.filters.searchText
+              ? ' (search: "' + state.filters.searchText + '")'
+              : '');
+          computeLayout();
+          draw();
+        });
+
+        window.addEventListener('resize', resizeCanvas);
+
+        resizeCanvas();
+        window.parent.postMessage({ type: 'vispubs:ready' }, '*');
+      })();
+    </script>
+  </body>
+</html>

--- a/quasar.config.js
+++ b/quasar.config.js
@@ -98,7 +98,7 @@ module.exports = configure(function (/* ctx */) {
       // directives: [],
 
       // Quasar plugins
-      plugins: ['Notify', 'Meta'],
+      plugins: ['Notify', 'Meta', 'Dialog'],
     },
 
     // animations: 'all', // --- includes all animations

--- a/src/components/PluginHost.vue
+++ b/src/components/PluginHost.vue
@@ -157,7 +157,7 @@ function maybePromptAndLoad(): void {
       `<p>This page wants to load a plugin from <b>${escapeHtml(
         originLabel.value
       )}</b>.</p>` +
-      `<p>Plugins run in a sandboxed iframe and can display visualizations using the public paper data. They cannot read your cookies, local storage, or anything else on vispubs.com.</p>` +
+      '<p>Plugins run in a sandboxed iframe and can display visualizations using the public paper data. They cannot read your cookies, local storage, or anything else on vispubs.com.</p>' +
       '<p>Only load plugins from sources you trust.</p>',
     html: true,
     persistent: true,

--- a/src/components/PluginHost.vue
+++ b/src/components/PluginHost.vue
@@ -1,0 +1,291 @@
+<script setup lang="ts">
+import { ref, computed, watch, onMounted, onBeforeUnmount } from 'vue';
+import { debounce, useQuasar } from 'quasar';
+
+import { usePluginStore } from 'src/stores/pluginStore';
+import { usePaperDataStore, type PaperInfo } from 'src/stores/paperDataStore';
+import { useGlobalStore } from 'src/stores/globalStore';
+
+import type {
+  PluginFilterState,
+  PluginPaper,
+  PluginStatePayload,
+  PluginToHostMessage,
+} from 'src/types/plugin';
+
+const $q = useQuasar();
+const pluginStore = usePluginStore();
+const paperDataStore = usePaperDataStore();
+const globalStore = useGlobalStore();
+
+const iframeRef = ref<HTMLIFrameElement | null>(null);
+const pluginReady = ref<boolean>(false);
+const dialogOpen = ref<boolean>(false);
+
+const originLabel = computed<string>(() => {
+  if (!pluginStore.pluginUrl) return '';
+  try {
+    return new URL(pluginStore.pluginUrl, window.location.origin).origin;
+  } catch {
+    return pluginStore.pluginUrl;
+  }
+});
+
+const iframeSrc = computed<string | null>(() => {
+  const url = pluginStore.pluginUrl;
+  if (!url) return null;
+  if (!pluginStore.isTrusted(url)) return null;
+  return url;
+});
+
+function toPluginPaper(p: PaperInfo): PluginPaper {
+  return {
+    doi: p.doi,
+    title: p.title,
+    year: p.year,
+    conference: p.conference,
+    award: p.award,
+    authorNamesDeduped: p.authorNamesDeduped,
+    abstract: p.abstract,
+    resources: p.resources,
+    accessible: p.accessible,
+    early: p.early,
+  };
+}
+
+function buildFilterState(): PluginFilterState {
+  return {
+    searchText: paperDataStore.searchText ?? '',
+    matchCase: paperDataStore.matchCase !== null,
+    useRegex: paperDataStore.useRegex !== null,
+    yearFilter: paperDataStore.yearFilterSet
+      ? {
+          min: paperDataStore.yearFilter.min,
+          max: paperDataStore.yearFilter.max,
+        }
+      : null,
+    venueFilter: Array.from(paperDataStore.venueFilter).sort(),
+    awardFilter: Array.from(paperDataStore.awardFilter).sort(),
+    resourceFilter: Array.from(paperDataStore.resourceFilter).sort(),
+    collection: paperDataStore.collectionKey ?? null,
+  };
+}
+
+function buildState(): PluginStatePayload {
+  const focusIdx = paperDataStore.focusedPaperIndex;
+  const focusedDoi =
+    focusIdx != null && paperDataStore.papers[focusIdx]
+      ? paperDataStore.papers[focusIdx].doi
+      : null;
+  return {
+    type: 'vispubs:state',
+    papers: paperDataStore.papers.map(toPluginPaper),
+    filters: buildFilterState(),
+    selectedDoi: paperDataStore.selectedPaper?.doi ?? null,
+    focusedDoi,
+    darkMode: globalStore.darkMode,
+  };
+}
+
+function postState(): void {
+  if (!pluginReady.value) return;
+  const win = iframeRef.value?.contentWindow;
+  if (!win) return;
+  win.postMessage(buildState(), '*');
+}
+
+const debouncedPostState = debounce(postState, 150);
+
+function onMessage(event: MessageEvent): void {
+  const iframe = iframeRef.value;
+  if (!iframe || event.source !== iframe.contentWindow) return;
+
+  const data = event.data as { type?: unknown } | null;
+  if (!data || typeof data.type !== 'string') return;
+  if (!data.type.startsWith('vispubs:')) return;
+
+  const msg = data as PluginToHostMessage;
+  switch (msg.type) {
+    case 'vispubs:ready':
+      pluginReady.value = true;
+      postState();
+      return;
+    case 'vispubs:selectPaper':
+      if (typeof msg.doi === 'string') {
+        const index = paperDataStore.papers.findIndex(
+          (p) => p.doi === msg.doi
+        );
+        if (index >= 0) paperDataStore.selectPaper(index);
+      }
+      return;
+    case 'vispubs:focusPaper':
+      if (msg.doi == null) {
+        paperDataStore.clearFocusedPaper();
+        return;
+      }
+      if (typeof msg.doi === 'string') {
+        const index = paperDataStore.papers.findIndex(
+          (p) => p.doi === msg.doi
+        );
+        if (index >= 0) paperDataStore.focusedPaperIndex = index;
+      }
+      return;
+  }
+}
+
+watch(
+  () => [
+    paperDataStore.papers,
+    paperDataStore.selectedPaper?.doi,
+    paperDataStore.focusedPaperIndex,
+    globalStore.darkMode,
+  ],
+  () => debouncedPostState(),
+  { deep: true }
+);
+
+function maybePromptAndLoad(): void {
+  const url = pluginStore.pluginUrl;
+  if (!url) return;
+  if (pluginStore.isTrusted(url)) return;
+  if (dialogOpen.value) return;
+
+  dialogOpen.value = true;
+  $q.dialog({
+    title: 'Load third-party plugin?',
+    message:
+      `<p>This page wants to load a plugin from <b>${escapeHtml(
+        originLabel.value
+      )}</b>.</p>` +
+      `<p>Plugins run in a sandboxed iframe and can display visualizations using the public paper data. They cannot read your cookies, local storage, or anything else on vispubs.com.</p>` +
+      '<p>Only load plugins from sources you trust.</p>',
+    html: true,
+    persistent: true,
+    ok: { label: 'Load plugin', color: 'primary' },
+    cancel: { label: 'Cancel', flat: true },
+  })
+    .onOk(() => {
+      pluginStore.trustUrl(url);
+    })
+    .onCancel(() => {
+      pluginStore.closePlugin();
+    })
+    .onDismiss(() => {
+      dialogOpen.value = false;
+    });
+}
+
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+watch(
+  () => pluginStore.pluginUrl,
+  () => {
+    pluginReady.value = false;
+    maybePromptAndLoad();
+  }
+);
+
+onMounted(() => {
+  window.addEventListener('message', onMessage);
+  maybePromptAndLoad();
+});
+
+onBeforeUnmount(() => {
+  window.removeEventListener('message', onMessage);
+});
+
+function close(): void {
+  pluginStore.closePlugin();
+}
+</script>
+
+<template>
+  <div class="plugin-host column">
+    <div class="plugin-host__header row items-center q-px-sm q-py-xs">
+      <q-icon name="extension" size="sm" class="q-mr-sm" />
+      <div
+        class="plugin-host__title ellipsis"
+        :title="pluginStore.pluginUrl ?? ''"
+      >
+        Plugin · {{ originLabel }}
+      </div>
+      <q-space />
+      <q-btn
+        dense
+        flat
+        round
+        :icon="
+          pluginStore.pluginOrientation === 'horizontal'
+            ? 'swap_horiz'
+            : 'swap_vert'
+        "
+        :title="`Switch to ${
+          pluginStore.pluginOrientation === 'horizontal'
+            ? 'vertical'
+            : 'horizontal'
+        } layout`"
+        @click="pluginStore.toggleOrientation()"
+      />
+      <q-btn
+        dense
+        flat
+        round
+        icon="close"
+        title="Close plugin"
+        @click="close"
+      />
+    </div>
+    <div class="plugin-host__body col">
+      <iframe
+        v-if="iframeSrc"
+        ref="iframeRef"
+        :src="iframeSrc"
+        sandbox="allow-scripts"
+        class="plugin-host__iframe"
+      />
+      <div v-else class="plugin-host__placeholder text-center q-pa-md">
+        Waiting for plugin approval…
+      </div>
+    </div>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.plugin-host {
+  width: 100%;
+  height: 100%;
+  min-height: 0;
+  min-width: 0;
+  border: 1px solid rgba(128, 128, 128, 0.3);
+}
+.plugin-host__header {
+  border-bottom: 1px solid rgba(128, 128, 128, 0.3);
+  background: rgba(128, 128, 128, 0.08);
+  flex: 0 0 auto;
+}
+.plugin-host__title {
+  font-size: 0.9rem;
+  max-width: 60%;
+}
+.plugin-host__body {
+  position: relative;
+  min-height: 0;
+  min-width: 0;
+}
+.plugin-host__iframe {
+  width: 100%;
+  height: 100%;
+  border: 0;
+  display: block;
+}
+.plugin-host__placeholder {
+  color: rgba(128, 128, 128, 0.8);
+}
+</style>

--- a/src/components/PluginHost.vue
+++ b/src/components/PluginHost.vue
@@ -140,8 +140,7 @@ watch(
     paperDataStore.focusedPaperIndex,
     globalStore.darkMode,
   ],
-  () => debouncedPostState(),
-  { deep: true }
+  () => debouncedPostState()
 );
 
 function maybePromptAndLoad(): void {

--- a/src/pages/IndexPage.vue
+++ b/src/pages/IndexPage.vue
@@ -4,13 +4,16 @@ import { useWindowSize } from '@vueuse/core';
 import { useKeypress } from 'vue3-keypress';
 
 import { usePaperDataStore } from 'src/stores/paperDataStore';
+import { usePluginStore } from 'src/stores/pluginStore';
 import { useSeo } from 'src/composables/useSeo';
 const paperDataStore = usePaperDataStore();
+const pluginStore = usePluginStore();
 useSeo();
 
 import PaperInformation from 'src/components/PaperInformation.vue';
 import PaperList from 'src/components/PaperList.vue';
 import FilterPanel from 'src/components/FilterPanel.vue';
+import PluginHost from 'src/components/PluginHost.vue';
 
 const rightDrawerOpen = computed(() => paperDataStore.selectedPaper !== null);
 
@@ -87,8 +90,21 @@ function focusNextPaper() {
   </q-drawer>
   <q-page-container>
     <q-page class="items-center">
-      <div v-if="paperDataStore.allData" :data-nosnippet="rightDrawerOpen ? '' : undefined">
-        <PaperList />
+      <div
+        v-if="paperDataStore.allData"
+        :data-nosnippet="rightDrawerOpen ? '' : undefined"
+        class="plugin-split"
+        :style="{
+          flexDirection:
+            pluginStore.pluginOrientation === 'horizontal' ? 'row' : 'column',
+        }"
+      >
+        <div class="plugin-split__pane">
+          <PaperList />
+        </div>
+        <div v-if="pluginStore.pluginUrl" class="plugin-split__pane plugin-split__pane--plugin">
+          <PluginHost />
+        </div>
       </div>
       <div v-else class="q-ma-lg">loading...</div>
     </q-page>
@@ -101,5 +117,22 @@ a {
 
 .no-scroll-x {
   overflow-x: hidden;
+}
+
+.plugin-split {
+  display: flex;
+  width: 100%;
+  min-height: calc(100vh - 50px);
+  align-items: stretch;
+}
+
+.plugin-split__pane {
+  flex: 1 1 0;
+  min-width: 0;
+  min-height: 0;
+}
+
+.plugin-split__pane--plugin {
+  display: flex;
 }
 </style>

--- a/src/stores/pluginStore.ts
+++ b/src/stores/pluginStore.ts
@@ -1,0 +1,92 @@
+import { ref, watch } from 'vue';
+import { useRouter } from 'vue-router';
+import { defineStore } from 'pinia';
+
+export type PluginOrientation = 'horizontal' | 'vertical';
+
+export const usePluginStore = defineStore('pluginStore', () => {
+  const { currentRoute, push } = useRouter();
+
+  function updateQueryState(params: {
+    [parameter: string]: string | null;
+  }): void {
+    const query = { ...currentRoute.value.query };
+    for (const parameter in params) {
+      const value = params[parameter];
+      if (query[parameter] === value) continue;
+      if (value === null) {
+        delete query[parameter];
+      } else {
+        query[parameter] = value;
+      }
+    }
+    push({ query }).catch((e) => {
+      console.log(e);
+    });
+  }
+
+  const pluginUrl = ref<string | null>(
+    (currentRoute.value.query.plugin as string) ?? null
+  );
+
+  const pluginOrientation = ref<PluginOrientation>(
+    currentRoute.value.query.pluginOrientation === 'vertical'
+      ? 'vertical'
+      : 'horizontal'
+  );
+
+  // Session-scoped set of URLs the user has approved in this tab.
+  // Not URL-synced — sharing a link must always re-prompt.
+  const trustedUrls = ref<Set<string>>(new Set<string>());
+
+  watch(
+    currentRoute,
+    (to, from) => {
+      if (to.query.plugin !== from.query.plugin) {
+        pluginUrl.value = (to.query.plugin as string) ?? null;
+      }
+      if (to.query.pluginOrientation !== from.query.pluginOrientation) {
+        pluginOrientation.value =
+          to.query.pluginOrientation === 'vertical' ? 'vertical' : 'horizontal';
+      }
+    },
+    { deep: true }
+  );
+
+  function setPluginUrl(url: string | null): void {
+    pluginUrl.value = url;
+    updateQueryState({ plugin: url });
+  }
+
+  function closePlugin(): void {
+    setPluginUrl(null);
+  }
+
+  function toggleOrientation(): void {
+    const next: PluginOrientation =
+      pluginOrientation.value === 'horizontal' ? 'vertical' : 'horizontal';
+    pluginOrientation.value = next;
+    // Horizontal is the default — omit from the URL when default.
+    updateQueryState({
+      pluginOrientation: next === 'horizontal' ? null : next,
+    });
+  }
+
+  function trustUrl(url: string): void {
+    trustedUrls.value.add(url);
+  }
+
+  function isTrusted(url: string): boolean {
+    return trustedUrls.value.has(url);
+  }
+
+  return {
+    pluginUrl,
+    pluginOrientation,
+    setPluginUrl,
+    closePlugin,
+    toggleOrientation,
+    trustUrl,
+    isTrusted,
+  };
+});

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -1,0 +1,55 @@
+export interface PluginPaper {
+  doi: string;
+  title: string;
+  year: number;
+  conference: string;
+  award: string;
+  authorNamesDeduped: string;
+  abstract: string;
+  resources?: string;
+  accessible: boolean;
+  early: boolean;
+}
+
+export interface PluginFilterState {
+  searchText: string;
+  matchCase: boolean;
+  useRegex: boolean;
+  yearFilter: { min: number; max: number } | null;
+  venueFilter: string[];
+  awardFilter: string[];
+  resourceFilter: string[];
+  collection: string | null;
+}
+
+export interface PluginStatePayload {
+  type: 'vispubs:state';
+  papers: PluginPaper[];
+  filters: PluginFilterState;
+  selectedDoi: string | null;
+  focusedDoi: string | null;
+  darkMode: boolean;
+}
+
+export type HostToPluginMessage = PluginStatePayload;
+
+export interface PluginReadyMessage {
+  type: 'vispubs:ready';
+}
+
+export interface PluginSelectPaperMessage {
+  type: 'vispubs:selectPaper';
+  doi: string;
+}
+
+export interface PluginFocusPaperMessage {
+  type: 'vispubs:focusPaper';
+  doi: string | null;
+}
+
+export type PluginToHostMessage =
+  | PluginReadyMessage
+  | PluginSelectPaperMessage
+  | PluginFocusPaperMessage;
+
+export const VISPUBS_MESSAGE_PREFIX = 'vispubs:';


### PR DESCRIPTION
## Summary
- Adds a third-party plugin system: any URL that serves HTML/JS can be loaded into a sandboxed iframe alongside the paper list.
- Plugin is activated per session via `?plugin=<url>`; orientation persists via `?pluginOrientation=horizontal|vertical`. A session-scoped confirmation dialog gates loading.
- Host and plugin communicate via a strict `vispubs:`-prefixed `postMessage` protocol with bidirectional filter/selection/focus sync.
- Ships a self-contained reference plugin at `public/plugins/example-scatterplot.html`.

## Changes
- `src/types/plugin.ts` — exported `HostToPluginMessage` / `PluginToHostMessage` union types + filter-state shape so plugin authors can import them.
- `src/stores/pluginStore.ts` — Pinia store holding `pluginUrl`, `pluginOrientation` (URL-synced) and a session-scoped set of trusted URLs. Follows the route-watcher + `updateQueryState` pattern from `paperDataStore`.
- `src/components/PluginHost.vue` — renders `<iframe sandbox="allow-scripts">` (no `allow-same-origin`, no forms, no storage, no popups), header with origin label / orientation swap / close `x`, confirm dialog on first load of a new URL, and the `postMessage` bridge with `event.source` validation, `vispubs:` prefix check, and ~150 ms debounced state broadcasts.
- `src/pages/IndexPage.vue` — replaces the `<PaperList />` wrapper with a flex container that conditionally renders `<PluginHost />` 50/50; `flex-direction` is bound to the store's orientation. Collapses to the original single-pane layout when no plugin is active.
- `public/plugins/example-scatterplot.html` — reference plugin plotting year × within-year index on a canvas; click selects, hover focuses, redraws on resize, honors dark mode.
- `docs/plugins.md` + README link — protocol reference, security model, minimal plugin template, out-of-scope list.
- `quasar.config.js` — register Quasar `Dialog` plugin (needed by `$q.dialog`).

## Spec
Feature spec: [`.claude/todo/add-plugin-framework.md`](./.claude/todo/done/add-plugin-framework.md) (moved to `done/` as part of this branch).

Security model: `allow-scripts` without `allow-same-origin` makes the iframe an opaque origin — it cannot read cookies, `localStorage`, the parent DOM, or any other origin's data. All host-sent data is from the already-public `papers.csv`. The confirm dialog is defense-in-depth against someone sharing a `vispubs.com/?plugin=...` link with unexpected code.

## Test plan
- [ ] `yarn dev`, open `/` — list, filters, detail drawer behave as before (zero regression when no plugin is active).
- [ ] `/?plugin=/plugins/example-scatterplot.html` — approval dialog appears; after approval, split layout renders with PaperList on the left and scatter on the right.
- [ ] Search / filter toggles update the scatterplot's points live.
- [ ] Clicking a scatter point opens the detail drawer; clicking a list row updates the scatter's selected styling.
- [ ] Hovering a scatter point focuses the corresponding list row.
- [ ] Orientation button swaps row/column layout and updates the URL.
- [ ] Close `x` tears down the iframe and removes `?plugin=` from the URL.
- [ ] Reloading preserves `?plugin=` and re-prompts the dialog.
- [ ] Sharing the URL into a new tab restores the same state (and re-prompts).
- [ ] A cross-origin gist URL works end-to-end.
- [ ] `yarn build` succeeds with no TypeScript errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)